### PR TITLE
FIPS enabled for operator image

### DIFF
--- a/build/images/training-operator/Dockerfile
+++ b/build/images/training-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -13,11 +13,13 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager cmd/training-operator.v1/main.go
+USER root
+RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -tags strictfipsruntime -a -o manager cmd/training-operator.v1/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
+USER 65532:65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This issue makes a couple of changes
1.  It switches to Red Hat UBI images
2. It compiles the go module with the flags `CGO_ENABLED=1` and `-tags strictfipsruntime` 
3. It switches the image to non-root to close a high security item.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #https://issues.redhat.com/browse/RHOAIENG-3277

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
N/A

Testing:
I did the following:
1.  Built the image, pushed it to quay and scanned it with check-payload
```
git clone https://github.com/jbusche/training-operator.git -b jbusche-FIPS-enable
cd training-operator/
podman build -f build/images/training-operator/Dockerfile -t training-operator:v1-fipstry6 .
        
podman tag localhost/training-operator:v1-fipstry6 quay.io/jbusche/training-operator:v1-fipstry6
podman push quay.io/jbusche/training-operator:v1-fipstry6
        
./check-payload scan operator -V 4.13 --spec quay.io/jbusche/training-operator:v1-fipstry5
---- Successful run

2.  In an installed KFTO environment, I swapped out my new image
```
oc edit deploy training-operator  -n kubeflow

and change the training operator image to what I built above:
image: quay.io/jbusche/training-operator:v1-fipstry6
```
3.  the training operator reboots, and then I submit a simple example to test it:
```
oc apply -f examples/pytorch/simple.yaml
```
4. Then I watch it with:
```
oc get pytorchjobs,pods -n kubeflow                                                          api.jimfips.cp.fyre.ibm.com: Thu Mar  7 15:14:44 2024

NAME                                     STATE       AGE
pytorchjob.kubeflow.org/pytorch-simple   Succeeded   7m57s

NAME                                    READY   STATUS      RESTARTS   AGE
pod/pytorch-simple-master-0             0/1     Completed   0          7m57s
pod/pytorch-simple-worker-0             0/1     Completed   0          7m48s
pod/training-operator-597dc6f74-jxrl9   1/1     Running     0          10m
```

