### PR TITLE
ODH Image build actions

### DIFF
--- a/.github/workflows/odh-build-and-publish-operator-image.yaml
+++ b/.github/workflows/odh-build-and-publish-operator-image.yaml
@@ -1,0 +1,125 @@
+# This is a copy of the publish-core-images.yaml and has been customized to
+# use the quay login credentials.
+# The unused parts of the original have been commented out on purpose.
+name: ODH
+
+on:
+  - push
+  - pull_request
+
+jobs:
+    build-and-publish-operator:
+      name: Build and (or) Publish Image
+      runs-on: ubuntu-latest  
+      env:
+        GOPATH: ${{ github.workspace }}/go
+        REPO_NAME: ${{ vars.QUAY_REPO_NAME || 'opendatahub' }}
+      steps:
+        - name: Environment dump
+          shell: bash
+          run: |
+            echo "GOPATH = ${GOPATH}"
+            echo "REPO_NAME = ${REPO_NAME}"
+        
+        - name: Checkout
+          uses: actions/checkout@v4
+          
+        - name: Set up Go
+          uses: actions/setup-go@v5
+          with:
+            go-version-file: go.mod
+
+        - name: Run go mod
+          shell: bash
+          run: |
+            go mod download
+                
+        # Build operators inside the gh runner vm directly and then copy the go binaries to docker images using the Dockerfile.buildx
+        - name: Build linux/amd64 operator binary
+          env:
+            CGO_ENABLED: 1
+            GOOS: linux
+            GOARCH: amd64
+          shell: bash
+          run: |
+            go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
+   
+        - name: Build linux/arm64 operator binary
+          env:
+            CC: aarch64-linux-gnu-gcc
+            CGO_ENABLED: 1
+            GOOS: linux
+            GOARCH: arm64
+          shell: bash
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+            go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
+
+        - name: Add docker tags
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: quay.io/${{ env.REPO_NAME }}/training-operator
+            tags: |
+              type=raw,latest
+              type=ref,event=pr
+              type=sha,prefix=v1-odh-  
+  
+        - name: Build image 
+          id: build-image
+          uses: redhat-actions/buildah-build@v2
+          with:
+            image: quay.io/${{ env.REPO_NAME }}/training-operator
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            platforms: linux/amd64,linux/arm64 
+            containerfiles: |
+              build/images/training-operator/Dockerfile.multiarch
+            extra-args: |
+              --pull  
+        
+        # Check if image is build
+        - name: Check images created
+          shell: bash
+          run: buildah images | grep 'quay.io/${{ env.REPO_NAME }}/training-operator'
+
+        - name: Check image manifest
+          shell: bash
+          run: |
+            buildah manifest inspect ${{ steps.build-image.outputs.image }}:latest      
+    
+
+        - name: Check image metadata
+          shell: bash  
+          run: |
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.OCIv1.config.Labels."org.opencontainers.image.title"'
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.OCIv1.config.Labels."org.opencontainers.image.description"'
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.Docker.config.Labels."org.opencontainers.image.title"'
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.Docker.config.Labels."org.opencontainers.image.description"'
+                
+        - name: Login to Quay.io
+          id: podman-login-quay
+          # Trigger step only for specific branch (master, v.*-branch) or tag (v.*).
+          if:  (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/tags/v')) 
+          shell: bash
+          run: |
+              podman login --username ${{ secrets.QUAY_USERNAME }} --password ${{ secrets.QUAY_TOKEN }} quay.io
+
+        - name: Push to Quay.io
+          if:  always() && steps.podman-login-quay.outcome == 'success' 
+          id: push-to-quay
+          uses: redhat-actions/push-to-registry@v2
+          with:
+            image: ${{ steps.build-image.outputs.image }}
+            tags: ${{ steps.build-image.outputs.tags }}
+        
+        - name: Print image url
+          if: steps.push-to-quay.outcome == 'success'
+          shell: bash  
+          run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+  
+        - name: Logout from Quay.io
+          if: always() && steps.podman-login-quay.outcome == 'success'
+          run: |
+            podman logout quay.io 

--- a/build/images/training-operator/Dockerfile.multiarch
+++ b/build/images/training-operator/Dockerfile.multiarch
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+ARG TARGETARCH
+WORKDIR /
+COPY ./manager-${TARGETARCH} ./manager
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add's ODH workflows to build and publish to quay.io training operator images

**Which issue(s) this PR fixe\
Fixes # https://issues.redhat.com/browse/RHOAIENG-4838?filter=-1

**Checklist:**
Valided this work in my own fork, runs of this workflow can be seen here:
* release /tag based: https://github.com/z103cb/training-operator/actions/runs/8552572065
* push / pr based: https://github.com/z103cb/training-operator/actions/runs/8552491007

Images can be seen here:
https://quay.io/repository/laurentiu_bradin/training-operator?tab=tags

This workflow will need these secrets to be defined:
* `QUAY_USERNAME` -- quay user name
* `QUAY_TOKEN` -- quay encrypted token.
Also this workflow will need this environment variable defined:
* `QUAY_REPO_NAME` -- quay namespace / repo

