### PR TITLE
Disable e2e sft-trainer test

### DIFF
--- a/test/e2e/kfto_kueue_sft_test.go
+++ b/test/e2e/kfto_kueue_sft_test.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 /*
 Copyright 2023.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Resolving GHA [erros](https://github.com/opendatahub-io/training-operator/actions/runs/8567363840/job/23479011409?pr=4) in PRs 

- Disable SFTTrainer KFTO in go test run by GH action
