### PR TITLE
CARRY: Add upstream metadata to Training Operator manifests

### DIFF
--- a/manifests/rhoai/component_metadata.yaml
+++ b/manifests/rhoai/component_metadata.yaml
@@ -1,0 +1,5 @@
+releases:
+  - name: Kubeflow Training Operator
+    version: 1.8.0-rc.0
+    repoUrl: https://github.com/kubeflow/training-operator
+    


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Added upstream metadata to the training operator manifests

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

[RHOAIENG-15701](https://issues.redhat.com/browse/RHOAIENG-15701)

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
