### PR TITLE
CARRY: Add nslookup to the operator container image

### DIFF
--- a/build/images/training-operator/Dockerfile.rhoai
+++ b/build/images/training-operator/Dockerfile.rhoai
@@ -19,6 +19,9 @@ RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -tags strictfipsruntime -a 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf update && microdnf install -y bind-utils
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
This adds `nslookup` to the training operator container image, so it can be used as init container for the training jobs.

Part of [RHOAIENG-18489](https://issues.redhat.com/browse/RHOAIENG-18489).
