### PR TITLE
fix: manifests not replace image but left variable

### DIFF
--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -30,16 +30,6 @@ replacements:
       name: training-operator
     fieldPaths:
     - spec.template.spec.containers.0.image
-  - source:
-    kind: ConfigMap
-    name: rhoai-config
-    version: v1
-    fieldPath: data.odh-training-operator-controller-image
-  targets:
-  - select:
-      kind: Deployment
-      name: training-operator
-    fieldPaths:
     - spec.template.spec.containers.0.args.2
 
 # Labels to add to all resources and selectors.

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -30,6 +30,17 @@ replacements:
       name: training-operator
     fieldPaths:
     - spec.template.spec.containers.0.image
+  - source:
+    kind: ConfigMap
+    name: rhoai-config
+    version: v1
+    fieldPath: data.odh-training-operator-controller-image
+  targets:
+  - select:
+      kind: Deployment
+      name: training-operator
+    fieldPaths:
+    - spec.template.spec.containers.0.args.2
 
 # Labels to add to all resources and selectors.
 labels:

--- a/manifests/rhoai/manager_config_patch.yaml
+++ b/manifests/rhoai/manager_config_patch.yaml
@@ -10,3 +10,5 @@ spec:
         image: $(image)
         args:
         - "--zap-log-level=2"
+        - --pytorch-init-container-image
+        - $(image)

--- a/manifests/rhoai/params.yaml
+++ b/manifests/rhoai/params.yaml
@@ -1,3 +1,5 @@
 varReference:
   - path: spec/template/spec/containers[]/image
     kind: Deployment
+  - path: spec/template/spec/containers[]/args[2]
+    kind: Deployment


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
fix a problem with adding init container:
```
spec:
      containers:
      - args:
        - --zap-log-level=2
        - --pytorch-init-container-image
        - quay.io/opendatahub/training-operator:v1-odh-c7d4e1b
        command:
        - /manager
        env:
        - name: MY_POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: MY_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        image: $(image)
```
test result:
```
    spec:
      containers:
      - args:
        - --zap-log-level=2
        - --pytorch-init-container-image
        - quay.io/opendatahub/training-operator:v1-odh-c7d4e1b
        command:
        - /manager
        env:
        - name: MY_POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: MY_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        image: quay.io/opendatahub/training-operator:v1-odh-c7d4e1b
```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
