### PR TITLE
Update the repo_Url with the rename of repo in upstream

### DIFF
--- a/manifests/component_metadata.yaml
+++ b/manifests/component_metadata.yaml
@@ -1,4 +1,4 @@
 releases:
   - name: Kubeflow Training Operator
     version: "1.9.0"
-    repoUrl: https://github.com/kubeflow/training-operator
+    repoUrl: https://github.com/kubeflow/trainer


### PR DESCRIPTION

**What this PR does / why we need it**:
Update the repo_Url in component_metadata file as the repo has renamed in upstream


Fixes # 

**Checklist:**

- [X] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
