### PR TITLE
Adding timeout to allow for commit to be ready before create PR action

### DIFF
--- a/.github/workflows/odh-kfto-sdk-notebooks-sync.yaml
+++ b/.github/workflows/odh-kfto-sdk-notebooks-sync.yaml
@@ -147,6 +147,9 @@ jobs:
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$REPO_OWNER/$REPO_NAME.git
           git push origin ${{ env.UPDATER_BRANCH }}
 
+      - name: Wait for commit to propagate
+        run: sleep 15
+
       - name: Create Pull Request
         run: |
           gh pr create --repo $UPSTREAM_OWNER/$UPSTREAM_REPO_NAME \


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Adds a timeout to allow the commit to be ready before attempting to create the PR.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
