### PR TITLE
Add s390x architecture support and configure test builds for Quay.io

### DIFF
--- a/.github/workflows/odh-build-and-publish-operator-image.yaml
+++ b/.github/workflows/odh-build-and-publish-operator-image.yaml
@@ -4,8 +4,14 @@
 name: ODH
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - dev
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - dev
 
 jobs:
     build-and-publish-operator:
@@ -65,6 +71,7 @@ jobs:
               type=raw,latest
               type=ref,event=pr
               type=sha,prefix=v1-odh-  
+              type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
   
         - name: Build image 
           id: build-image

--- a/.github/workflows/odh-build-and-publish-operator-image.yaml
+++ b/.github/workflows/odh-build-and-publish-operator-image.yaml
@@ -1,0 +1,125 @@
+# This is a copy of the publish-core-images.yaml and has been customized to
+# use the quay login credentials.
+# The unused parts of the original have been commented out on purpose.
+name: ODH
+
+on:
+  - push
+  - pull_request
+
+jobs:
+    build-and-publish-operator:
+      name: Build and (or) Publish Image
+      runs-on: ubuntu-latest  
+      env:
+        GOPATH: ${{ github.workspace }}/go
+        REPO_NAME: ${{ vars.QUAY_REPO_NAME || 'opendatahub' }}
+      steps:
+        - name: Environment dump
+          shell: bash
+          run: |
+            echo "GOPATH = ${GOPATH}"
+            echo "REPO_NAME = ${REPO_NAME}"
+        
+        - name: Checkout
+          uses: actions/checkout@v4
+          
+        - name: Set up Go
+          uses: actions/setup-go@v5
+          with:
+            go-version-file: go.mod
+
+        - name: Run go mod
+          shell: bash
+          run: |
+            go mod download
+                
+        # Build operators inside the gh runner vm directly and then copy the go binaries to docker images using the Dockerfile.buildx
+        - name: Build linux/amd64 operator binary
+          env:
+            CGO_ENABLED: 1
+            GOOS: linux
+            GOARCH: amd64
+          shell: bash
+          run: |
+            go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
+   
+        - name: Build linux/arm64 operator binary
+          env:
+            CC: aarch64-linux-gnu-gcc
+            CGO_ENABLED: 1
+            GOOS: linux
+            GOARCH: arm64
+          shell: bash
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+            go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
+
+        - name: Add docker tags
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: quay.io/${{ env.REPO_NAME }}/training-operator
+            tags: |
+              type=raw,latest
+              type=ref,event=pr
+              type=sha,prefix=v1-odh-  
+  
+        - name: Build image 
+          id: build-image
+          uses: redhat-actions/buildah-build@v2
+          with:
+            image: quay.io/${{ env.REPO_NAME }}/training-operator
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            platforms: linux/amd64,linux/arm64 
+            containerfiles: |
+              build/images/training-operator/Dockerfile.multiarch
+            extra-args: |
+              --pull  
+        
+        # Check if image is build
+        - name: Check images created
+          shell: bash
+          run: buildah images | grep 'quay.io/${{ env.REPO_NAME }}/training-operator'
+
+        - name: Check image manifest
+          shell: bash
+          run: |
+            buildah manifest inspect ${{ steps.build-image.outputs.image }}:latest      
+    
+
+        - name: Check image metadata
+          shell: bash  
+          run: |
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.OCIv1.config.Labels."org.opencontainers.image.title"'
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.OCIv1.config.Labels."org.opencontainers.image.description"'
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.Docker.config.Labels."org.opencontainers.image.title"'
+              buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.Docker.config.Labels."org.opencontainers.image.description"'
+                
+        - name: Login to Quay.io
+          id: podman-login-quay
+          # Trigger step only for specific branch (master, v.*-branch) or tag (v.*).
+          if:  (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/tags/v')) 
+          shell: bash
+          run: |
+              podman login --username ${{ secrets.QUAY_USERNAME }} --password ${{ secrets.QUAY_TOKEN }} quay.io
+
+        - name: Push to Quay.io
+          if:  always() && steps.podman-login-quay.outcome == 'success' 
+          id: push-to-quay
+          uses: redhat-actions/push-to-registry@v2
+          with:
+            image: ${{ steps.build-image.outputs.image }}
+            tags: ${{ steps.build-image.outputs.tags }}
+        
+        - name: Print image url
+          if: steps.push-to-quay.outcome == 'success'
+          shell: bash  
+          run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+  
+        - name: Logout from Quay.io
+          if: always() && steps.podman-login-quay.outcome == 'success'
+          run: |
+            podman logout quay.io 

--- a/.github/workflows/odh-build-and-publish-operator-image.yaml
+++ b/.github/workflows/odh-build-and-publish-operator-image.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
     build-and-publish-operator:
       name: Build and (or) Publish Image
-      runs-on: ubuntu-latest  
+      runs-on: ubuntu-latest
       env:
         GOPATH: ${{ github.workspace }}/go
         REPO_NAME: ${{ vars.QUAY_REPO_NAME || 'opendatahub' }}
@@ -26,10 +26,10 @@ jobs:
           run: |
             echo "GOPATH = ${GOPATH}"
             echo "REPO_NAME = ${REPO_NAME}"
-        
+
         - name: Checkout
           uses: actions/checkout@v4
-          
+
         - name: Set up Go
           uses: actions/setup-go@v5
           with:
@@ -39,7 +39,7 @@ jobs:
           shell: bash
           run: |
             go mod download
-                
+
         # Build operators inside the gh runner vm directly and then copy the go binaries to docker images using the Dockerfile.buildx
         - name: Build linux/amd64 operator binary
           env:
@@ -49,7 +49,7 @@ jobs:
           shell: bash
           run: |
             go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
-   
+
         - name: Build linux/arm64 operator binary
           env:
             CC: aarch64-linux-gnu-gcc
@@ -70,22 +70,22 @@ jobs:
             tags: |
               type=raw,latest
               type=ref,event=pr
-              type=sha,prefix=v1-odh-  
+              type=sha,prefix=v1-odh-
               type=ref,enable=true,priority=600,prefix=,suffix=,event=tag
-  
-        - name: Build image 
+
+        - name: Build image
           id: build-image
           uses: redhat-actions/buildah-build@v2
           with:
             image: quay.io/${{ env.REPO_NAME }}/training-operator
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}
-            platforms: linux/amd64,linux/arm64 
+            platforms: linux/amd64,linux/arm64
             containerfiles: |
               build/images/training-operator/Dockerfile.multiarch
             extra-args: |
-              --pull  
-        
+              --pull
+
         # Check if image is build
         - name: Check images created
           shell: bash
@@ -94,39 +94,39 @@ jobs:
         - name: Check image manifest
           shell: bash
           run: |
-            buildah manifest inspect ${{ steps.build-image.outputs.image }}:latest      
-    
+            buildah manifest inspect ${{ steps.build-image.outputs.image }}:latest
+
 
         - name: Check image metadata
-          shell: bash  
+          shell: bash
           run: |
               buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.OCIv1.config.Labels."org.opencontainers.image.title"'
               buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.OCIv1.config.Labels."org.opencontainers.image.description"'
               buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.Docker.config.Labels."org.opencontainers.image.title"'
               buildah inspect ${{ steps.build-image.outputs.image-with-tag }} | jq '.Docker.config.Labels."org.opencontainers.image.description"'
-                
+
         - name: Login to Quay.io
           id: podman-login-quay
           # Trigger step only for specific branch (master, v.*-branch) or tag (v.*).
-          if:  (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/tags/v')) 
+          if:  (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/heads/v') && endsWith(github.ref, '-branch')) || startsWith(github.ref, 'refs/tags/v'))
           shell: bash
           run: |
               podman login --username ${{ secrets.QUAY_USERNAME }} --password ${{ secrets.QUAY_TOKEN }} quay.io
 
         - name: Push to Quay.io
-          if:  always() && steps.podman-login-quay.outcome == 'success' 
+          if:  always() && steps.podman-login-quay.outcome == 'success'
           id: push-to-quay
           uses: redhat-actions/push-to-registry@v2
           with:
             image: ${{ steps.build-image.outputs.image }}
             tags: ${{ steps.build-image.outputs.tags }}
-        
+
         - name: Print image url
           if: steps.push-to-quay.outcome == 'success'
-          shell: bash  
+          shell: bash
           run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
-  
+
         - name: Logout from Quay.io
           if: always() && steps.podman-login-quay.outcome == 'success'
           run: |
-            podman logout quay.io 
+            podman logout quay.io

--- a/.github/workflows/odh-build-and-publish-operator-image.yaml
+++ b/.github/workflows/odh-build-and-publish-operator-image.yaml
@@ -61,6 +61,18 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross
             go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
+            
+        - name: Build linux/s390x operator binary
+          env:
+            CC: s390x-linux-gnu-gcc
+            CGO_ENABLED: 1
+            GOOS: linux
+            GOARCH: s390x
+          shell: bash
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y gcc-s390x-linux-gnu libc6-dev-s390x-cross
+            go build -tags strictfipsruntime -a -o manager-$GOARCH cmd/training-operator.v1/main.go
 
         - name: Add docker tags
           id: meta
@@ -80,7 +92,7 @@ jobs:
             image: quay.io/${{ env.REPO_NAME }}/training-operator
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64,linux/arm64,linux/s390x
             containerfiles: |
               build/images/training-operator/Dockerfile.multiarch
             extra-args: |

--- a/.github/workflows/odh-kfto-sdk-notebooks-sync.yaml
+++ b/.github/workflows/odh-kfto-sdk-notebooks-sync.yaml
@@ -147,6 +147,9 @@ jobs:
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$REPO_OWNER/$REPO_NAME.git
           git push origin ${{ env.UPDATER_BRANCH }}
 
+      - name: Wait for commit to propagate
+        run: sleep 15
+
       - name: Create Pull Request
         run: |
           gh pr create --repo $UPSTREAM_OWNER/$UPSTREAM_REPO_NAME \

--- a/.github/workflows/odh-kfto-sdk-notebooks-sync.yaml
+++ b/.github/workflows/odh-kfto-sdk-notebooks-sync.yaml
@@ -1,0 +1,162 @@
+# The aim of this GitHub workflow is to update the pipfile to sync with Kubeflow Training release.
+name: Sync ODH-notebooks with Kubeflow-Training SDK release
+on:
+  workflow_dispatch:
+    inputs:
+      upstream-notebooks-repository-organization:
+        required: true
+        description: "Owner of target upstream notebooks repository used to open a PR against"
+        default: "opendatahub-io"
+      notebooks-target-branch:
+        required: true
+        description: "Target branch of upstream repository"
+        default: "main"
+      python-version:
+        required: true
+        description: "Provide the python version to be used for the notebooks"
+        default: "3.11"
+      notebooks-repository-organization:
+        required: true
+        description: "Owner of origin notebooks repository used to open a PR"
+        default: "opendatahub-io"
+      notebooks-repository-name:
+        required: true
+        description: "Name of origin notebooks repository used to open a PR"
+        default: "training-notebooks"
+      training-sdk-release-version:
+        required: true
+        description: "Provide version of the kubeflow-training-sdk release"
+
+env:
+  BRANCH_NAME: ${{ github.event.inputs.notebooks-target-branch }}
+  PYTHON_VERSION: ${{ github.event.inputs.python-version }}
+  TRAINING_SDK_RELEASE_VERSION: ${{ github.event.inputs.training-sdk-release-version }}
+  UPDATER_BRANCH: odh-sync-updater-${{ github.run_id }}
+  UPSTREAM_OWNER: ${{ github.event.inputs.upstream-notebooks-repository-organization }}
+  UPSTREAM_REPO_NAME: notebooks
+  REPO_OWNER: ${{ github.event.inputs.notebooks-repository-organization }}
+  REPO_OWNER_USER_EMAIL: kubeflow_training@redhat.com
+  REPO_OWNER_USER_NAME: kubeflow-training
+  REPO_NAME: ${{ github.event.inputs.notebooks-repository-name }}
+  GITHUB_TOKEN: ${{ secrets.KUBEFLOW_TRAINING_ACCOUNT_TOKEN }} # add KUBEFLOW_TRAINING_ACCOUNT_TOKEN named secret in your notebooks repo to be used here (Rights/Scopes required : repo & workflow)
+  MINIMUM_SUPPORTED_PYTHON_VERSION: 3.9
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository and Sync
+        run: |
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/$REPO_OWNER/$REPO_NAME.git $REPO_NAME
+          cd $REPO_NAME
+          git remote add upstream https://github.com/$UPSTREAM_OWNER/$UPSTREAM_REPO_NAME.git
+          git config --global user.email $REPO_OWNER_USER_EMAIL
+          git config --global user.name $REPO_OWNER_USER_NAME
+          git remote -v
+          git checkout $BRANCH_NAME
+          git config pull.rebase true
+          git pull upstream $BRANCH_NAME && git push -f origin $BRANCH_NAME
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pipenv'
+
+      - name: Install pipenv and pip-versions
+        run: pip install pipenv==2024.4.0 pip-versions
+
+      - name: Update Pipfiles in accordance with Kubeflow Training latest release
+        run: |
+            package_name=kubeflow-training
+            available_python_versions=("$PYTHON_VERSION") # add space separated python versions according to 'python-versions' specified in 'Setup Python Environment' step
+            install_package_using_pipenv(){
+                # args allow custom names for Pipfile and Pipfile.lock
+                if [ $# -eq 2 ]; then
+                    mv "${1}" Pipfile
+                    mv "${2}" Pipfile.lock
+                fi
+                # replace existing version of cf-sdk with new version in Pipfile
+                sed -i "s/$package_name = \"==[^\"]*\"/$package_name = \"==${TRAINING_SDK_RELEASE_VERSION}\"/" Pipfile
+                # restore names as they were before
+                if [ $# -eq 2 ]; then
+                    mv Pipfile "${1}"
+                    mv Pipfile.lock "${2}"
+                fi
+            }
+            # Get the list of available versions for the package
+            if ! versions=$(pipenv run pip-versions list $package_name);then
+                echo "Failed to retrieve versions for $package_name"
+                exit 1
+            fi
+            # Check if the desired version exists in the list
+            if echo "$versions" | grep -q "${TRAINING_SDK_RELEASE_VERSION}"; then
+                echo "Version ${TRAINING_SDK_RELEASE_VERSION} is available for $package_name"
+                directories+=($(grep --exclude-dir=.git --exclude-dir=.github --exclude-dir=intel --exclude-dir=tensorflow --exclude-dir=rocm-tensorflow --include="Pipfile*" -rl "$package_name = \"==[0-9.]*\"" | xargs dirname | sort | uniq))
+                counter=0
+                total=${#directories[@]}
+                echo -----------
+                for dir in "${directories[@]}"; do
+                  counter=$((counter+1))
+                  echo "--Processing directory $counter '$dir' of total $total"
+                  cd "$dir"
+                  minimum_supported_python_version_major=$(echo "${MINIMUM_SUPPORTED_PYTHON_VERSION}" | awk -F '.' '{print $1}') #integer of MINIMUM_SUPPORTED_PYTHON_VERSION env variable
+                  minimum_supported_python_version_minor=$(echo "${MINIMUM_SUPPORTED_PYTHON_VERSION}" | awk -F '.' '{print $2}') #decimal of MINIMUM_SUPPORTED_PYTHON_VERSION env variable
+                  if ! [ -f "Pipfile" ]; then
+                      if [ -f "Pipfile.cpu" ]; then
+                          pipfile_python_version=$(grep -E '^python_version' ./Pipfile.cpu | cut -d '"' -f 2) # extracted from pipfile.cpu
+                      fi
+                  else
+                      pipfile_python_version=$(grep -E '^python_version' ./Pipfile | cut -d '"' -f 2) # extracted from pipfile
+                  fi
+                  pipfile_python_version_major=$(echo "$pipfile_python_version" | awk -F '.' '{print $1}')
+                  pipfile_python_version_minor=$(echo "$pipfile_python_version" | awk -F '.' '{print $2}')
+                  if [[ " ${available_python_versions[@]} " =~ " ${pipfile_python_version} " && "$pipfile_python_version_major" -ge "$minimum_supported_python_version_major" && "$pipfile_python_version_minor" -ge "$minimum_supported_python_version_minor" ]]; then
+                      if ! [ -f "Pipfile" ]; then
+                          if [ -f "Pipfile.cpu" ]; then
+                              install_package_using_pipenv Pipfile.cpu Pipfile.lock.cpu
+                          fi
+                          if [ -f "Pipfile.gpu" ]; then
+                              install_package_using_pipenv Pipfile.gpu Pipfile.lock.gpu
+                          fi
+                      else
+                          #install specified package
+                          install_package_using_pipenv
+                      fi
+                      else
+                      echo "Skipped installation of ${package_name} with version ${TRAINING_SDK_RELEASE_VERSION} in $dir"
+                  fi
+                  cd -
+                  echo "$((total-counter)) directories remaining.."
+                done
+                # Refresh Pipfile.Lock files
+                cd $REPO_NAME && make refresh-pipfilelock-files && cd -
+            else
+                versions_list=$(echo "$versions" | tr '\n' '   ' | sed 's/, $//')
+                versions="${versions_list%,}"
+                echo "Version '${TRAINING_SDK_RELEASE_VERSION}' is not available for $package_name"
+                echo "Available versions for $package_name: $versions"
+                exit 1
+            fi
+
+      - name: Push changes
+        run: |
+          cd $REPO_NAME
+          git add . && git status && git checkout -b ${{ env.UPDATER_BRANCH }} && \
+          git commit -am "Updated notebooks via ${{ env.UPDATER_BRANCH }} GitHub action" --signoff  &&
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$REPO_OWNER/$REPO_NAME.git
+          git push origin ${{ env.UPDATER_BRANCH }}
+
+      - name: Create Pull Request
+        run: |
+          gh pr create --repo $UPSTREAM_OWNER/$UPSTREAM_REPO_NAME \
+            --title "$pr_title" \
+            --body "$pr_body" \
+            --head $REPO_OWNER:$UPDATER_BRANCH \
+            --base $BRANCH_NAME
+        env:
+          pr_title: "[Kubeflow-Training Action] Update notebook's pipfile to sync with Kubeflow-Training SDK release ${{ env.TRAINING_SDK_RELEASE_VERSION }}"
+          pr_body: |
+            :rocket: This is an automated Pull Request generated by [odh-kfto-sdk-notebooks-sync.yml](https://github.com/opendatahub-io/training-operator/tree/dev/.github/workflows/odh-kfto-sdk-notebooks-sync.yml) workflow.
+
+            This PR updates the `Pipfile` to sync with latest Kubeflow-Training SDK release.

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -1,0 +1,46 @@
+# This workflow will handle the release process
+
+name: ODH Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to be used for release, i.e.: v0.0.1-odh-1'
+        required: true
+  push:
+    tags:
+      - '*'
+jobs:
+  release-odh:
+    runs-on: ubuntu-latest
+
+    # Permission required to create a release
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: './go.mod'
+
+    - name: Verify that release doesn't exist yet
+      shell: bash {0}
+      run: |
+        gh release view ${{ github.event.inputs.version }}
+        status=$?
+        if [[ $status -eq 0 ]]; then
+          echo "Release ${{ github.event.inputs.version }} already exists."
+          exit 1
+        fi
+      env:
+        GITHUB_TOKEN: ${{ github.TOKEN }}
+
+    - name: Creates a release in GitHub
+      run: |
+        gh release create ${{ github.event.inputs.version }} --target ${{ github.ref }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+      shell: bash

--- a/.github/workflows/publish-conformance-images.yaml
+++ b/.github/workflows/publish-conformance-images.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/build-and-publish-images.yaml
     with:
       component-name: ${{ matrix.component-name }}
-      platforms: linux/amd64,linux/arm64,linux/ppc64le
+      platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
       dockerfile: ${{ matrix.dockerfile }}
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: amd64,ppc64le,arm64
+        platforms: amd64,ppc64le,arm64,s390x
 
     - name: Set Up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd manifests/overlays/standalone && $(KUSTOMIZE) edit set image kubeflow/training-operator=${IMG}
-	$(KUSTOMIZE) build manifests/overlays/standalone | kubectl apply -f -
+	$(KUSTOMIZE) build manifests/overlays/standalone | kubectl apply --server-side -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build manifests/overlays/standalone | kubectl delete -f -

--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,7 @@ approvers:
 reviewers:
   - abhijeet-dhumal
   - astefanutti
-  - ChughShilpa 
+  - ChughShilpa
   - Fiona-Waters
-  - oksanabaza 
+  - oksanabaza
   - sutaakar

--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,12 @@
 approvers:
-  - andreyvelich
-  - gaocegege
-  - Jeffwan
-  - johnugeorge
-  - tenzen-y
-  - terrytangyuan
+  - astefanutti
+  - Fiona-Waters
+  - sutaakar
+
 reviewers:
-  - jinchihe
-  - kuizhiqing
-emeritus_approvers:
-  - zw0610
+  - abhijeet-dhumal
+  - astefanutti
+  - ChughShilpa 
+  - Fiona-Waters
+  - oksanabaza 
+  - sutaakar

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ Please refer to the [CONTRIBUTING guide](CONTRIBUTING.md).
 
 Please refer to the [CHANGELOG](CHANGELOG.md).
 
+## Release
+
+### ⚠️ EXTREMELY IMPORTANT ⚠️
+
+**Whenever you rebase this fork onto a new upstream release, you _must_ update the version in
+[component_metadata.yaml](https://github.com/opendatahub-io/training-operator/blob/dev/manifests/component_metadata.yaml).**
+This version is displayed to customers via the `DataScienceCluster` resource, so it must remain accurate.
+
+If a new ODH release is planned, ensure the updated version is also posted in the
+release tracker.        See example: [Issue #170](https://github.com/opendatahub-io/opendatahub-community/issues/170).
+
 ## Version Matrix
 
 The following table lists the most recent few versions of the operator.

--- a/build/images/training-operator/Dockerfile.multiarch
+++ b/build/images/training-operator/Dockerfile.multiarch
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+ARG TARGETARCH
+WORKDIR /
+COPY ./manager-${TARGETARCH} ./manager
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/build/images/training-operator/Dockerfile.multiarch
+++ b/build/images/training-operator/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ARG TARGETARCH
 WORKDIR /
 COPY ./manager-${TARGETARCH} ./manager

--- a/build/images/training-operator/Dockerfile.rhoai
+++ b/build/images/training-operator/Dockerfile.rhoai
@@ -1,0 +1,43 @@
+ARG GOLANG_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.23
+# Go versioning workaround for lack of go-toolset for version 1.23
+FROM ${GOLANG_IMAGE} AS golang
+
+FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
+
+ARG GOLANG_VERSION=1.23.0
+
+# Install system dependencies
+RUN dnf upgrade -y && dnf install -y \
+    gcc \
+    make \
+    openssl-devel \
+    && dnf clean all && rm -rf /var/cache/yum
+
+# Install Go
+ENV PATH=/usr/local/go/bin:$PATH
+
+ARG GOLANG_DIR=/usr/lib/golang
+COPY --from=golang ${GOLANG_DIR} /usr/local/go
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY . .
+
+# Build
+USER root
+RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -tags strictfipsruntime -a -o manager cmd/training-operator.v1/main.go
+
+# Runtime
+FROM registry.access.redhat.com/ubi9/ubi:latest
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+ENTRYPOINT ["/manager"]

--- a/build/images/training-operator/Dockerfile.rhoai
+++ b/build/images/training-operator/Dockerfile.rhoai
@@ -37,6 +37,8 @@ RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -tags strictfipsruntime -a 
 # Runtime
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
+RUN dnf update && dnf install -y bind-utils
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/build/images/training-operator/Dockerfile.rhoai
+++ b/build/images/training-operator/Dockerfile.rhoai
@@ -1,23 +1,4 @@
-ARG GOLANG_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.23
-# Go versioning workaround for lack of go-toolset for version 1.23
-FROM ${GOLANG_IMAGE} AS golang
-
-FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
-
-ARG GOLANG_VERSION=1.23.0
-
-# Install system dependencies
-RUN dnf upgrade -y && dnf install -y \
-    gcc \
-    make \
-    openssl-devel \
-    && dnf clean all && rm -rf /var/cache/yum
-
-# Install Go
-ENV PATH=/usr/local/go/bin:$PATH
-
-ARG GOLANG_DIR=/usr/lib/golang
-COPY --from=golang ${GOLANG_DIR} /usr/local/go
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -53,7 +53,7 @@ const (
 	// EnvKubeflowNamespace is an environment variable for namespace when deployed on kubernetes
 	EnvKubeflowNamespace = "KUBEFLOW_NAMESPACE"
 
-	webhookConfigurationName = "validator.training-operator.kubeflow.org"
+	webhookConfigurationName = "kubeflow-validator.training-operator.kubeflow.org"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/training-operator
 
-go 1.23
+go 1.23.2
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/kubeflow/training-operator
 
 go 1.23
+
 toolchain go1.23.2
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/kubeflow/training-operator
 
-go 1.23.2
+go 1.23
+toolchain go1.23.2
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -290,3 +290,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/manifests/base/webhook/patch.yaml
+++ b/manifests/base/webhook/patch.yaml
@@ -1,18 +1,18 @@
 - op: replace
   path: /webhooks/0/clientConfig/service/name
-  value: training-operator
+  value: kubeflow-training-operator
 - op: replace
   path: /webhooks/1/clientConfig/service/name
-  value: training-operator
+  value: kubeflow-training-operator
 - op: replace
   path: /webhooks/2/clientConfig/service/name
-  value: training-operator
+  value: kubeflow-training-operator
 - op: replace
   path: /webhooks/3/clientConfig/service/name
-  value: training-operator
+  value: kubeflow-training-operator
 - op: replace
   path: /webhooks/4/clientConfig/service/name
-  value: training-operator
+  value: kubeflow-training-operator
 - op: replace
   path: /metadata/name
   value: validator.training-operator.kubeflow.org

--- a/manifests/component_metadata.yaml
+++ b/manifests/component_metadata.yaml
@@ -1,0 +1,5 @@
+releases:
+  - name: Kubeflow Training Operator
+    version: "1.9.0"
+    repoUrl: https://github.com/kubeflow/training-operator
+    

--- a/manifests/component_metadata.yaml
+++ b/manifests/component_metadata.yaml
@@ -2,4 +2,3 @@ releases:
   - name: Kubeflow Training Operator
     version: "1.9.0"
     repoUrl: https://github.com/kubeflow/training-operator
-    

--- a/manifests/component_metadata.yaml
+++ b/manifests/component_metadata.yaml
@@ -1,4 +1,4 @@
 releases:
   - name: Kubeflow Training Operator
     version: "1.9.0"
-    repoUrl: https://github.com/kubeflow/training-operator
+    repoUrl: https://github.com/kubeflow/trainer

--- a/manifests/rhoai/kubeflow-training-roles.yaml
+++ b/manifests/rhoai/kubeflow-training-roles.yaml
@@ -1,0 +1,73 @@
+#This file has been copied from  ../overlays/kubeflow
+#The original labels have ben commented out for documentation purposes
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: training-edit
+  labels:
+#    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+#    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: training-view
+  labels:
+#    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -1,0 +1,45 @@
+# RHOAI configuration for Kubeflow Training Operator (KFTO)
+
+# Adds namespace to all resources.
+namespace: opendatahub
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: kubeflow-
+
+configMapGenerator:
+- name: rhoai-config
+  envs:
+    - params.env
+
+configurations:
+  - params.yaml
+
+vars:
+- name: image
+  objref:
+    kind: ConfigMap
+    name: rhoai-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-training-operator-controller-image
+
+# Labels to add to all resources and selectors.
+commonLabels:
+  app.kubernetes.io/name: training-operator
+  app.kubernetes.io/component: controller
+
+resources:
+- ../base
+- kubeflow-training-roles.yaml
+- monitor.yaml
+
+patches:
+# Mount the controller config file for loading manager configurations
+# through a ComponentConfig type
+- path: manager_config_patch.yaml
+- path: manager_metrics_patch.yaml
+- path: manager_delete_metrics_service_patch.yaml

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -30,6 +30,7 @@ replacements:
       name: training-operator
     fieldPaths:
     - spec.template.spec.containers.0.image
+    - spec.template.spec.containers.0.args.2
 
 # Labels to add to all resources and selectors.
 labels:

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -44,9 +44,21 @@ resources:
 - kubeflow-training-roles.yaml
 - monitor.yaml
 
+secretGenerator:
+  - name: training-operator-webhook-cert
+    options:
+      disableNameSuffixHash: true
+
 patches:
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 - path: manager_config_patch.yaml
 - path: manager_metrics_patch.yaml
-- path: manager_delete_metrics_service_patch.yaml
+- patch: |-
+    - op: remove
+      path: /spec/ports/0
+  target:
+    group: ""
+    version: v1
+    kind: Service
+    name: training-operator

--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -18,19 +18,25 @@ configMapGenerator:
 configurations:
   - params.yaml
 
-vars:
-- name: image
-  objref:
+replacements:
+- source:
     kind: ConfigMap
     name: rhoai-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.odh-training-operator-controller-image
+    version: v1
+    fieldPath: data.odh-training-operator-controller-image
+  targets:
+  - select:
+      kind: Deployment
+      name: training-operator
+    fieldPaths:
+    - spec.template.spec.containers.0.image
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app.kubernetes.io/name: training-operator
-  app.kubernetes.io/component: controller
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: training-operator
 
 resources:
 - ../base

--- a/manifests/rhoai/manager_config_patch.yaml
+++ b/manifests/rhoai/manager_config_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: training-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name:  training-operator
+        image: $(image)
+        args:
+        - "--zap-log-level=2"

--- a/manifests/rhoai/manager_config_patch.yaml
+++ b/manifests/rhoai/manager_config_patch.yaml
@@ -10,3 +10,5 @@ spec:
         image: $(image)
         args:
         - "--zap-log-level=2"
+        - --pytorch-init-container-image
+        - $(image)

--- a/manifests/rhoai/manager_config_patch.yaml
+++ b/manifests/rhoai/manager_config_patch.yaml
@@ -12,3 +12,12 @@ spec:
         - "--zap-log-level=2"
         - --pytorch-init-container-image
         - $(image)
+        - "--webhook-secret-name"
+        - "kubeflow-training-operator-webhook-cert"
+        - "--webhook-service-name"
+        - "kubeflow-training-operator"
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kubeflow-training-operator-webhook-cert

--- a/manifests/rhoai/manager_delete_metrics_service_patch.yaml
+++ b/manifests/rhoai/manager_delete_metrics_service_patch.yaml
@@ -1,0 +1,6 @@
+# Delete the service created in base
+$patch: delete
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-operator

--- a/manifests/rhoai/manager_delete_metrics_service_patch.yaml
+++ b/manifests/rhoai/manager_delete_metrics_service_patch.yaml
@@ -1,6 +1,0 @@
-# Delete the service created in base
-$patch: delete
-apiVersion: v1
-kind: Service
-metadata:
-  name: training-operator

--- a/manifests/rhoai/manager_metrics_patch.yaml
+++ b/manifests/rhoai/manager_metrics_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: training-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: training-operator
+        ports:
+        - containerPort: 8080
+          name: metrics

--- a/manifests/rhoai/monitor.yaml
+++ b/manifests/rhoai/monitor.yaml
@@ -1,0 +1,12 @@
+# Prometheus Pod Monitor (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: training-operator-metrics-monitor
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: training-operator
+      app.kubernetes.io/component: controller
+  podMetricsEndpoints:
+    - port: metrics

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,0 +1,1 @@
+odh-training-operator-controller-image=docker.io/kubeflow/training-operator:v1-855e096

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,1 +1,1 @@
-odh-training-operator-controller-image=quay.io/opendatahub/training-operator:v1-odh-c7d4e1b
+odh-training-operator-controller-image=quay.io/opendatahub/training-operator:v1.9.0-odh-1

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,1 +1,1 @@
-odh-training-operator-controller-image=docker.io/kubeflow/training-operator:v1-855e096
+odh-training-operator-controller-image=quay.io/opendatahub/training-operator:v1-odh-c7d4e1b

--- a/manifests/rhoai/params.env
+++ b/manifests/rhoai/params.env
@@ -1,1 +1,1 @@
-odh-training-operator-controller-image=quay.io/opendatahub/training-operator:v1.9.0-odh-1
+odh-training-operator-controller-image=quay.io/opendatahub/training-operator:v1.9.0-odh-3

--- a/manifests/rhoai/params.yaml
+++ b/manifests/rhoai/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment


### PR DESCRIPTION
# Add s390x Architecture Support

## Changes
- Added s390x binary build configuration in ODH workflow:
  - Added gcc-s390x-linux-gnu and libc6-dev-s390x-cross dependencies
  - Configured s390x-specific build environment variables

- Updated platform support in workflows:
  - Added linux/s390x to platforms list in conformance images
  - Added linux/s390x to platforms list in kubectl-delivery image
  - Updated QEMU setup to include s390x architecture

## Testing
- Verified s390x binary builds successfully
- Tested multi-arch image building with s390x support
- https://github.com/Nash-123/training-operator/actions/runs/15807763095/job/44554919460

c.c: @modassarrana89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the linux/s390x architecture in operator and conformance image builds and publishing workflows.

- **Chores**
  - Updated workflow configurations to enable multi-architecture builds, now including linux/s390x alongside existing platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->