### PR TITLE
Add RHOAI manifests missed during upstream rebase #70

### DIFF
--- a/manifests/rhoai/kubeflow-training-roles.yaml
+++ b/manifests/rhoai/kubeflow-training-roles.yaml
@@ -1,0 +1,73 @@
+#This file has been copied from  ../overlays/kubeflow
+#The original labels have ben commented out for documentation purposes
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: training-edit
+  labels:
+#    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+#    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-training-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: training-view
+  labels:
+#    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs
+      - tfjobs
+      - pytorchjobs
+      - mxjobs
+      - xgboostjobs
+      - paddlejobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - mpijobs/status
+      - tfjobs/status
+      - pytorchjobs/status
+      - mxjobs/status
+      - xgboostjobs/status
+      - paddlejobs/status
+    verbs:
+      - get

--- a/manifests/rhoai/manager_metrics_patch.yaml
+++ b/manifests/rhoai/manager_metrics_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: training-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: training-operator
+        ports:
+        - containerPort: 8080
+          name: metrics

--- a/manifests/rhoai/monitor.yaml
+++ b/manifests/rhoai/monitor.yaml
@@ -1,0 +1,12 @@
+# Prometheus Pod Monitor (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: training-operator-metrics-monitor
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: training-operator
+      app.kubernetes.io/component: controller
+  podMetricsEndpoints:
+    - port: metrics

--- a/manifests/rhoai/params.yaml
+++ b/manifests/rhoai/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new roles for managing and viewing Kubeflow training jobs within the platform.
  * Introduced a deployment for the training operator, exposing a metrics endpoint.
  * Enabled Prometheus monitoring for the training operator via a new PodMonitor resource.
  * Added configuration for parameterizing container images in deployment resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->