### PR TITLE
Convert checkpointing annotations to env vars

### DIFF
--- a/pkg/controller.v1/pytorch/envvar.go
+++ b/pkg/controller.v1/pytorch/envvar.go
@@ -33,6 +33,8 @@ const (
 	EnvNnodes = "PET_NNODES"
 	// EnvNodeRank is the environment variable name for the rank of nodes.
 	EnvNodeRank = "PET_NODE_RANK"
+	// CheckpointAnnotationEnvVarPrefix is the prefix of the environment variable name for the annotation.
+	CheckpointAnnotationPrefix = "checkpoint.config.kubeflow.org/"
 )
 
 // EnvVarGenerator is the environment variable generator interface.
@@ -51,6 +53,14 @@ func setPodEnv(obj interface{}, podTemplateSpec *corev1.PodTemplateSpec, rtype, 
 		if len(podTemplateSpec.Spec.Containers[i].Env) == 0 {
 			podTemplateSpec.Spec.Containers[i].Env = make([]corev1.EnvVar, 0)
 		}
+
+		// Inject checkpointing environment variables from annotations.
+		checkpointEnvVars := extractCheckpointEnvVars(pytorchjob)
+		if len(checkpointEnvVars) > 0 {
+			podTemplateSpec.Spec.Containers[i].Env = append(
+				podTemplateSpec.Spec.Containers[i].Env, checkpointEnvVars...)
+		}
+
 		// Set PYTHONUNBUFFERED to true, to disable output buffering.
 		// Ref https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file.
 		podTemplateSpec.Spec.Containers[i].Env = append(
@@ -165,4 +175,22 @@ func getPortFromPyTorchJob(job *kubeflowv1.PyTorchJob, rtype kubeflowv1.ReplicaT
 		}
 	}
 	return -1, fmt.Errorf("port not found")
+}
+
+func extractCheckpointEnvVars(pytorchjob *kubeflowv1.PyTorchJob) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+
+	if pytorchjob.GetAnnotations() == nil {
+		return envVars
+	}
+	for key, value := range pytorchjob.GetAnnotations() {
+		if strings.HasPrefix(key, CheckpointAnnotationPrefix) {
+			// remove the prefix
+			envVarName := strings.TrimPrefix(key, CheckpointAnnotationPrefix)
+			// convert to upper case and replace "-" with "_"
+			envVarName = strings.ToUpper(strings.ReplaceAll(envVarName, "-", "_"))
+			envVars = append(envVars, corev1.EnvVar{Name: envVarName, Value: value})
+		}
+	}
+	return envVars
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
[RHOAIENG-29321](https://issues.redhat.com/browse/RHOAIENG-29321)

**What this PR does / why we need it**:
This PR adds support for utilising annotations to propogate checkpointing related env vars to the PyTorchJob pod. The annotations are specified in the PyTorchJob yaml (via create_job api) for example:
```
annotations={
        "checkpoint.config.kubeflow.org/enable-checkpointing": "true",
        "checkpoint.config.kubeflow.org/checkpointing_storage-path": "/mnt/checkpoints"
    }
```

The values are extracted and injected as environment variables: 
```
env:
        - name: ENABLE_CHECKPOINTING
          value: 'true'
        - name: CHECKPOINTING_STORAGE_PATH
          value: /mnt/checkpoints
```
The env vars can be accessed in the training function:
```
os.getenv("CHECKPOINTING_STORAGE_PATH")
```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #[RHOAIENG-29321](https://issues.redhat.com/browse/RHOAIENG-29321)

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables are now automatically injected into PyTorchJob containers based on checkpoint-related annotations, making it easier to configure jobs using annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->