### PR TITLE
Telemetry P1 v1.6

### DIFF
--- a/manifests/rhoai/kustomization.yaml
+++ b/manifests/rhoai/kustomization.yaml
@@ -14,6 +14,11 @@ configMapGenerator:
 - name: rhoai-config
   envs:
     - params.env
+- name: telemetry-config
+  literals:
+    - TELEMETRY_ENABLED=true
+    - RECORDING_RULES_ENABLED=true
+    - METRICS_PORT=8080
 
 configurations:
   - params.yaml
@@ -43,6 +48,8 @@ resources:
 - ../base
 - kubeflow-training-roles.yaml
 - monitor.yaml
+# Telemetry resources
+- telemetry/
 
 secretGenerator:
   - name: training-operator-webhook-cert
@@ -54,11 +61,81 @@ patches:
 # through a ComponentConfig type
 - path: manager_config_patch.yaml
 - path: manager_metrics_patch.yaml
+# Add telemetry components (kube-rbac-proxy and env vars)
+- path: telemetry_patch.yaml
 - patch: |-
     - op: remove
       path: /spec/ports/0
   target:
     group: ""
     version: v1
+    kind: Service
+    name: training-operator
+
+# Add kube-rbac-proxy sidecar for secure metrics
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/-
+      value:
+        name: kube-rbac-proxy
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
+        args:
+          - --secure-listen-address=0.0.0.0:8443
+          - --upstream=http://127.0.0.1:8080/metrics
+          - --logtostderr=true
+          - --v=2
+        ports:
+          - containerPort: 8443
+            name: https-metrics
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+  target:
+    kind: Deployment
+    name: training-operator
+
+# Add telemetry environment variables
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: TELEMETRY_ENABLED
+        value: "true"
+  target:
+    kind: Deployment
+    name: training-operator
+
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: RECORDING_RULES_ENABLED
+        value: "true"
+  target:
+    kind: Deployment
+    name: training-operator
+
+# Update service to expose metrics port
+- patch: |-
+    - op: add
+      path: /spec/ports/-
+      value:
+        name: https-metrics
+        port: 8443
+        targetPort: https-metrics
+        protocol: TCP
+  target:
     kind: Service
     name: training-operator

--- a/manifests/rhoai/telemetry/kustomization.yaml
+++ b/manifests/rhoai/telemetry/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - servicemonitor.yaml
+  - otel-collector.yaml
+  - networkpolicy.yaml
+
+# Add telemetry-specific labels
+commonLabels:
+  app.kubernetes.io/part-of: training-operator
+  telemetry.opendatahub.io/enabled: "true"
+  monitoring.opendatahub.io/scrape: "true"

--- a/manifests/rhoai/telemetry/networkpolicy.yaml
+++ b/manifests/rhoai/telemetry/networkpolicy.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: training-operator-telemetry
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: training-operator
+  policyTypes:
+  - Ingress
+  ingress:
+  # Allow metrics scraping from monitoring namespaces
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443
+  # Allow OTEL collector access
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: otel-collector
+          app.kubernetes.io/component: telemetry
+    ports:
+    - protocol: TCP
+      port: 8443
+---
+# RBAC for metrics access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: training-operator-metrics
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: training-operator-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: training-operator-metrics
+subjects:
+- kind: ServiceAccount
+  name: training-operator-otel-collector
+  namespace: opendatahub

--- a/manifests/rhoai/telemetry/otel-collector.yaml
+++ b/manifests/rhoai/telemetry/otel-collector.yaml
@@ -1,0 +1,187 @@
+# ConfigMap for OpenTelemetry Collector configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: training-operator-otel-config
+data:
+  otel-config.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'training-operator'
+              kubernetes_sd_configs:
+                - role: service
+                  namespaces:
+                    names:
+                      - opendatahub
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_service_label_monitoring_opendatahub_io_scrape]
+                  action: keep
+                  regex: "true"
+              metric_relabel_configs:
+                # Keep only PRIMARY telemetry metric
+                - action: keep
+                  source_labels: [__name__]
+                  regex: 'training_jobs_total'
+                # Drop all others from export
+                - action: drop
+                  source_labels: [__name__]
+                  regex: '(training_operator_jobs_.*|kfto_.*|telemetry_errors_total)'
+
+    processors:
+      batch:
+        timeout: 10s
+        send_batch_size: 1024
+      
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 256
+        spike_limit_mib: 64
+
+      attributes:
+        actions:
+          - key: cluster_id
+            from_attribute: CLUSTER_ID
+            action: insert
+          - key: rhoai_version
+            value: "2.15.0"
+            action: insert
+
+    exporters:
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+        namespace: rhoai_telemetry
+        
+      otlp:
+        endpoint: "${OBSERVATORIUM_ENDPOINT}"
+        tls:
+          insecure: false
+        headers:
+          X-Tenant-ID: "${TENANT_ID}"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [memory_limiter, batch, attributes]
+          exporters: [prometheus, otlp]
+---
+# ServiceAccount for OpenTelemetry Collector
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: training-operator-otel-collector
+---
+# ClusterRole for OpenTelemetry Collector
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: training-operator-otel-collector
+rules:
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+  - servicemonitors
+  verbs: ["get", "list"]
+---
+# ClusterRoleBinding for OpenTelemetry Collector
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: training-operator-otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: training-operator-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: training-operator-otel-collector
+  namespace: opendatahub
+---
+# Deployment for OpenTelemetry Collector
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: training-operator-otel-collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/component: telemetry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/component: telemetry
+        app.kubernetes.io/part-of: training-operator
+    spec:
+      serviceAccountName: training-operator-otel-collector
+      containers:
+      - name: collector
+        image: registry.redhat.io/openshift-observability/otel-collector:latest
+        args:
+          - --config=/conf/otel-config.yaml
+        env:
+        - name: CLUSTER_ID
+          valueFrom:
+            configMapKeyRef:
+              name: cluster-config
+              key: cluster-id
+              optional: true
+        - name: TENANT_ID
+          valueFrom:
+            secretKeyRef:
+              name: telemetry-credentials
+              key: tenant-id
+              optional: true
+        - name: OBSERVATORIUM_ENDPOINT
+          value: "observatorium-gateway.observability.svc.cluster.local:443"
+        ports:
+        - containerPort: 8889
+          name: prometheus
+        volumeMounts:
+        - name: config
+          mountPath: /conf
+          readOnly: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      volumes:
+      - name: config
+        configMap:
+          name: training-operator-otel-config
+---
+# Service for OpenTelemetry Collector
+apiVersion: v1
+kind: Service
+metadata:
+  name: training-operator-otel-collector
+  labels:
+    monitoring.opendatahub.io/scrape: "true"
+spec:
+  selector:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/component: telemetry
+  ports:
+  - name: prometheus
+    port: 8889
+    targetPort: 8889
+    protocol: TCP

--- a/manifests/rhoai/telemetry/servicemonitor.yaml
+++ b/manifests/rhoai/telemetry/servicemonitor.yaml
@@ -1,0 +1,48 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: training-operator
+  annotations:
+    telemetry.opendatahub.io/description: "Training Operator usage metrics"
+    telemetry.opendatahub.io/max-cardinality: "10"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: training-operator
+  endpoints:
+  - port: https-metrics
+    path: /metrics
+    scheme: HTTPS
+    tlsConfig: {}
+    interval: 30s
+    metricRelabelings:
+      # Keep only the primary telemetry metric
+      - action: keep
+        regex: 'training_jobs_total'
+        sourceLabels: [__name__]
+      # Drop all other metrics from shipping
+      - action: drop
+        regex: '(training_operator_jobs_.*|kfto_.*|telemetry_errors_total)'
+        sourceLabels: [__name__]
+---
+# Recording rules for local dashboards
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: training-operator-recording
+spec:
+  groups:
+  - name: training_operator.rules
+    interval: 30s
+    rules:
+    - record: training:jobs:rate5m
+      expr: |
+        sum by (image_type, runtime_version) (
+          rate(training_jobs_total[5m])
+        )
+    
+    - record: training:jobs:increase1h
+      expr: |
+        sum by (image_type, runtime_version) (
+          increase(training_jobs_total[1h])
+        )

--- a/manifests/rhoai/telemetry_patch.yaml
+++ b/manifests/rhoai/telemetry_patch.yaml
@@ -1,0 +1,63 @@
+# Add kube-rbac-proxy sidecar for secure metrics
+- op: add
+  path: /spec/template/spec/containers/-
+  target:
+    kind: Deployment
+    name: training-operator
+  value:
+    name: kube-rbac-proxy
+    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
+    args:
+      - --secure-listen-address=0.0.0.0:8443
+      - --upstream=http://127.0.0.1:8080/metrics
+      - --logtostderr=true
+      - --v=2
+    ports:
+      - containerPort: 8443
+        name: https-metrics
+        protocol: TCP
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+
+# Add telemetry environment variables
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  target:
+    kind: Deployment
+    name: training-operator
+  value:
+    name: TELEMETRY_ENABLED
+    value: "true"
+
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  target:
+    kind: Deployment
+    name: training-operator
+  value:
+    name: RECORDING_RULES_ENABLED
+    value: "true"
+
+# Update service to expose metrics port
+- op: add
+  path: /spec/ports/-
+  target:
+    kind: Service
+    name: training-operator
+  value:
+    name: https-metrics
+    port: 8443
+    targetPort: https-metrics
+    protocol: TCP

--- a/pkg/common/metrics.go
+++ b/pkg/common/metrics.go
@@ -10,80 +10,93 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 package common
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// Define all the prometheus counters for all jobs
 var (
-	jobsCreatedCount = promauto.NewCounterVec(
+	initOnce sync.Once
+)
+
+// metrics preserved for backward compatibility
+var (
+	jobsCreatedCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "training_operator_jobs_created_total",
-			Help: "Counts number of jobs created",
+			Help: "Total number of training jobs created",
 		},
 		[]string{"job_namespace", "framework"},
 	)
-	jobsDeletedCount = promauto.NewCounterVec(
+
+	jobsDeletedCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "training_operator_jobs_deleted_total",
-			Help: "Counts number of jobs deleted",
+			Help: "Total number of training jobs deleted",
 		},
 		[]string{"job_namespace", "framework"},
 	)
-	jobsSuccessfulCount = promauto.NewCounterVec(
+
+	jobsSuccessfulCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "training_operator_jobs_successful_total",
-			Help: "Counts number of jobs successful",
+			Help: "Total number of successful training jobs",
 		},
 		[]string{"job_namespace", "framework"},
 	)
-	jobsFailedCount = promauto.NewCounterVec(
+
+	jobsFailedCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "training_operator_jobs_failed_total",
-			Help: "Counts number of jobs failed",
+			Help: "Total number of failed training jobs",
 		},
 		[]string{"job_namespace", "framework"},
 	)
-	jobsRestartedCount = promauto.NewCounterVec(
+
+	jobsRestartedCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "training_operator_jobs_restarted_total",
-			Help: "Counts number of jobs restarted",
+			Help: "Total number of restarted training jobs",
 		},
 		[]string{"job_namespace", "framework"},
 	)
 )
 
 func init() {
-	// Register custom metrics with the global prometheus registry
-	metrics.Registry.MustRegister(jobsCreatedCount,
-		jobsDeletedCount,
-		jobsSuccessfulCount,
-		jobsFailedCount,
-		jobsRestartedCount)
+	initOnce.Do(func() {
+		metrics.Registry.MustRegister(
+			jobsCreatedCount,
+			jobsDeletedCount,
+			jobsSuccessfulCount,
+			jobsFailedCount,
+			jobsRestartedCount,
+		)
+	})
 }
 
-func CreatedJobsCounterInc(job_namespace, framework string) {
-	jobsCreatedCount.WithLabelValues(job_namespace, framework).Inc()
+// compatibility functions
+func CreatedJobsCounterInc(jobNamespace, framework string) {
+	jobsCreatedCount.WithLabelValues(jobNamespace, framework).Inc()
 }
 
-func DeletedJobsCounterInc(job_namespace, framework string) {
-	jobsDeletedCount.WithLabelValues(job_namespace, framework).Inc()
+func DeletedJobsCounterInc(jobNamespace, framework string) {
+	jobsDeletedCount.WithLabelValues(jobNamespace, framework).Inc()
 }
 
-func SuccessfulJobsCounterInc(job_namespace, framework string) {
-	jobsSuccessfulCount.WithLabelValues(job_namespace, framework).Inc()
+func SuccessfulJobsCounterInc(jobNamespace, framework string) {
+	jobsSuccessfulCount.WithLabelValues(jobNamespace, framework).Inc()
 }
 
-func FailedJobsCounterInc(job_namespace, framework string) {
-	jobsFailedCount.WithLabelValues(job_namespace, framework).Inc()
+func FailedJobsCounterInc(jobNamespace, framework string) {
+	jobsFailedCount.WithLabelValues(jobNamespace, framework).Inc()
 }
 
-func RestartedJobsCounterInc(job_namespace, framework string) {
-	jobsRestartedCount.WithLabelValues(job_namespace, framework).Inc()
+func RestartedJobsCounterInc(jobNamespace, framework string) {
+	jobsRestartedCount.WithLabelValues(jobNamespace, framework).Inc()
 }

--- a/pkg/common/telemetry/classifier.go
+++ b/pkg/common/telemetry/classifier.go
@@ -1,0 +1,80 @@
+package telemetry
+
+import (
+	"strings"
+)
+
+const (
+	ImageTypeRHOAI  = "rhoai"
+	ImageTypeCustom = "custom"
+)
+
+func ClassifyImageSource(image string) string {
+	if image == "" {
+		return ImageTypeCustom
+	}
+
+	imageLower := strings.ToLower(image)
+
+	rhoaiRegistries := []string{
+		"quay.io/opendatahub/",
+		"quay.io/rhoai/",
+		"quay.io/modh/",
+		"registry.redhat.io/rhoai/",
+		"registry.redhat.io/ubi8/",
+		"registry.redhat.io/ubi9/",
+	}
+
+	for _, registry := range rhoaiRegistries {
+		if strings.Contains(imageLower, registry) {
+			return ImageTypeRHOAI
+		}
+	}
+
+	// RHOAI-specific image patterns
+	rhoaiPatterns := []string{
+		"pytorch-notebook",
+		"tensorflow-notebook",
+		"minimal-notebook",
+		"datascience-notebook",
+		"cuda-notebook",
+	}
+
+	for _, pattern := range rhoaiPatterns {
+		if strings.Contains(imageLower, pattern) &&
+			!strings.Contains(imageLower, "docker.io") &&
+			!strings.Contains(imageLower, "gcr.io") {
+			return ImageTypeRHOAI
+		}
+	}
+
+	return ImageTypeCustom
+}
+
+func ClassifyPyTorchVersion(image string) string {
+	if image == "" {
+		return "other"
+	}
+
+	imageLower := strings.ToLower(image)
+
+	// Check for supported versions in order of preference
+	versions := []string{"2.5", "2.4", "2.3", "2.2"}
+
+	for _, version := range versions {
+		patterns := []string{
+			"pytorch-" + version,
+			"pytorch:" + version,
+			"pytorch_" + version,
+			"-py" + strings.Replace(version, ".", "", -1),
+		}
+
+		for _, pattern := range patterns {
+			if strings.Contains(imageLower, pattern) {
+				return version
+			}
+		}
+	}
+
+	return "other"
+}

--- a/pkg/common/telemetry/collectors.go
+++ b/pkg/common/telemetry/collectors.go
@@ -1,0 +1,93 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+
+	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	logger           = ctrl.Log.WithName("telemetry")
+	telemetryEnabled = false
+)
+
+func init() {
+	// Check environment variable for telemetry enablement
+	if v := strings.ToLower(strings.TrimSpace(os.Getenv("TELEMETRY_ENABLED"))); v == "true" || v == "1" {
+		telemetryEnabled = true
+		logger.Info("Telemetry enabled")
+	}
+}
+
+func RecordPyTorchJobCreated(job *kubeflowv1.PyTorchJob) {
+	if !telemetryEnabled || job == nil {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			RecordTelemetryError()
+			logger.V(1).Info("Telemetry collection failed",
+				"operation", "RecordPyTorchJobCreated",
+				"error", r,
+				"job", job.Name)
+		}
+	}()
+
+	imageType, runtimeVersion := classifyJob(job)
+
+	trainingJobsTotal.WithLabelValues(imageType, runtimeVersion).Inc()
+
+	logger.V(3).Info("PyTorch job telemetry recorded",
+		"job", job.Name,
+		"image_type", imageType,
+		"runtime_version", runtimeVersion)
+}
+
+func classifyJob(job *kubeflowv1.PyTorchJob) (imageType, runtimeVersion string) {
+	image := extractPrimaryImage(job)
+	if image == "" {
+		return "custom", "other"
+	}
+
+	imageType = ClassifyImageSource(image)
+	runtimeVersion = ClassifyPyTorchVersion(image)
+
+	return imageType, runtimeVersion
+}
+
+func extractPrimaryImage(job *kubeflowv1.PyTorchJob) string {
+	// Check Master replica first if it exists
+	if spec, exists := job.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeMaster]; exists && spec != nil {
+		if image := getContainerImage(spec); image != "" {
+			return image
+		}
+	}
+
+	// Fall back to Worker replica
+	if spec, exists := job.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker]; exists && spec != nil {
+		if image := getContainerImage(spec); image != "" {
+			return image
+		}
+	}
+
+	return ""
+}
+
+func getContainerImage(spec *kubeflowv1.ReplicaSpec) string {
+	if spec.Template.Spec.Containers == nil || len(spec.Template.Spec.Containers) == 0 {
+		return ""
+	}
+
+	// Look for pytorch container first
+	for _, container := range spec.Template.Spec.Containers {
+		if container.Name == kubeflowv1.PyTorchJobDefaultContainerName || container.Name == "pytorch" {
+			return container.Image
+		}
+	}
+
+	// Fallback to first container
+	return spec.Template.Spec.Containers[0].Image
+}

--- a/pkg/common/telemetry/metrics.go
+++ b/pkg/common/telemetry/metrics.go
@@ -1,0 +1,116 @@
+package telemetry
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+)
+
+var (
+	once      sync.Once
+	k8sClient client.Client
+	mu        sync.RWMutex
+
+	trainingJobsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "training_jobs_total",
+			Help: "Total training jobs created by image type and runtime version",
+		},
+		[]string{"image_type", "runtime_version"},
+	)
+
+	//real-time gauge for current CRD instances
+	pytorchCRDInstances = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "pytorch_crd_instances",
+			Help: "Current number of PyTorchJob CRD instances in the cluster",
+		},
+		countPyTorchJobs,
+	)
+
+	// Customer classification info metric
+	trainingCustomerClassInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "training_customer_class_info",
+			Help: "Customer classification (prod, dev, ci, unknown) with value 1",
+		},
+		[]string{"class"},
+	)
+
+	//health metric
+	telemetryErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "telemetry_errors_total",
+			Help: "Errors encountered during telemetry collection",
+		},
+	)
+)
+
+// InitMetrics initializes all metrics with the provided K8s client
+func InitMetrics(c client.Client) {
+	once.Do(func() {
+		//Set the client before registering metrics
+		mu.Lock()
+		k8sClient = c
+		mu.Unlock()
+
+		metrics.Registry.MustRegister(
+			trainingJobsTotal,
+			pytorchCRDInstances,
+			trainingCustomerClassInfo,
+			telemetryErrors,
+		)
+
+		//set customer class info
+		customerClass := getCustomerClass()
+		trainingCustomerClassInfo.WithLabelValues(customerClass).Set(1)
+	})
+}
+
+func countPyTorchJobs() float64 {
+	mu.RLock()
+	c := k8sClient
+	mu.RUnlock()
+
+	if c == nil {
+		return 0
+	}
+
+	//short timeout to avoid stalling endpoint
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var list kubeflowv1.PyTorchJobList
+	if err := c.List(ctx, &list); err != nil {
+		RecordTelemetryError()
+		return 0
+	}
+
+	return float64(len(list.Items))
+}
+
+func getCustomerClass() string {
+	class := strings.ToLower(strings.TrimSpace(os.Getenv("KFTO_CUSTOMER_CLASS")))
+	switch class {
+	case "prod", "production":
+		return "prod"
+	case "dev", "development":
+		return "dev"
+	case "ci", "test", "testing":
+		return "ci"
+	default:
+		return "unknown"
+	}
+}
+
+func RecordTelemetryError() {
+	telemetryErrors.Inc()
+}

--- a/pkg/common/update.go
+++ b/pkg/common/update.go
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 package common
 
@@ -18,10 +18,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ClearGeneratedFields will clear the generated fields from the given object meta.
-// It is used to avoid problems like "the object has been modified; please apply your
-// changes to the latest version and try again".
+// ClearGeneratedFields clears the generated fields from the given object meta
 func ClearGeneratedFields(objmeta *metav1.ObjectMeta) {
 	objmeta.UID = ""
+	objmeta.ResourceVersion = ""
+	objmeta.Generation = 0
 	objmeta.CreationTimestamp = metav1.Time{}
+	objmeta.DeletionTimestamp = nil
+	objmeta.DeletionGracePeriodSeconds = nil
+	objmeta.ManagedFields = nil
 }

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -22,6 +22,7 @@ import (
 
 	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	trainingoperatorcommon "github.com/kubeflow/training-operator/pkg/common"
+	"github.com/kubeflow/training-operator/pkg/common/telemetry"
 	"github.com/kubeflow/training-operator/pkg/common/util"
 	"github.com/kubeflow/training-operator/pkg/controller.v1/common"
 	"github.com/kubeflow/training-operator/pkg/controller.v1/control"
@@ -64,6 +65,9 @@ const (
 
 // NewReconciler creates a PyTorchJob Reconciler
 func NewReconciler(mgr manager.Manager, gangSchedulingSetupFunc common.GangSchedulingSetupFunc) *PyTorchJobReconciler {
+	// Initialize telemetry metrics
+	telemetry.InitMetrics()
+
 	r := &PyTorchJobReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
@@ -118,12 +122,6 @@ type PyTorchJobReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// the PyTorchJob object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 	logger := r.Log.WithValues(kubeflowv1.PyTorchJobSingular, req.NamespacedName)
@@ -524,14 +522,20 @@ func (r *PyTorchJobReconciler) GetDefaultContainerPortName() string {
 	return kubeflowv1.PyTorchJobDefaultPortName
 }
 
-// onOwnerCreateFunc modify creation condition.
+// onOwnerCreateFunc modify creation condition and record telemetry.
 func (r *PyTorchJobReconciler) onOwnerCreateFunc() func(createEvent event.TypedCreateEvent[*kubeflowv1.PyTorchJob]) bool {
 	return func(e event.TypedCreateEvent[*kubeflowv1.PyTorchJob]) bool {
 		pytorchjob := e.Object
 		r.Scheme.Default(pytorchjob)
 		msg := fmt.Sprintf("PyTorchJob %s is created.", e.Object.GetName())
 		logrus.Info(msg)
+		
+		// Legacy metrics
 		trainingoperatorcommon.CreatedJobsCounterInc(pytorchjob.Namespace, r.GetFrameworkName())
+		
+		// Phase 1 telemetry
+		telemetry.RecordPyTorchJobCreated(pytorchjob)
+		
 		commonutil.UpdateJobConditions(&pytorchjob.Status, kubeflowv1.JobCreated, corev1.ConditionTrue, commonutil.NewReason(kubeflowv1.PyTorchJobKind, commonutil.JobCreatedReason), msg)
 		return true
 	}
@@ -556,7 +560,7 @@ func desiredPyTorchJobNetworkPolicy(job *kubeflowv1.PyTorchJob) *networkingv1ac.
 								WithValues("openshift-monitoring"))),
 					).
 					WithPorts(
-						networkingv1ac.NetworkPolicyPort().WithProtocol(corev1.ProtocolTCP).WithPort(intstr.FromInt(8080)),
+						networkingv1ac.NetworkPolicyPort().WithProtocol(corev1.ProtocolTCP).WithPort(intstr.FromInt(8443)),
 					),
 			),
 		).

--- a/scripts/test_telemetry.sh
+++ b/scripts/test_telemetry.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# KFTO Telemetry Phase 1 Test Script
+
+set -e
+
+NAMESPACE=${NAMESPACE:-opendatahub}
+
+echo "================================"
+echo "KFTO Telemetry Phase 1 Test"
+echo "================================"
+
+# Find training-operator pod
+echo "→ Finding training-operator pod..."
+OPERATOR_POD=$(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/name=training-operator -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+if [ -z "$OPERATOR_POD" ]; then
+    echo "✗ ERROR: Training operator not found in namespace: $NAMESPACE"
+    exit 1
+fi
+
+echo "✓ Found operator pod: $OPERATOR_POD"
+
+# Create test PyTorchJobs
+echo ""
+echo "Creating test PyTorchJobs..."
+
+# Test 1: RHOAI PyTorch 2.5 image
+cat <<EOF | kubectl apply -f -
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: test-rhoai-25
+  namespace: $NAMESPACE
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: quay.io/modh/pytorch:2.5.0-cuda-12.4-python-3.11
+            command: ["python", "-c", "print('RHOAI 2.5 test')"]
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+EOF
+
+# Test 2: RHOAI PyTorch 2.4 image
+cat <<EOF | kubectl apply -f -
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: test-rhoai-24
+  namespace: $NAMESPACE
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: quay.io/opendatahub/pytorch:2.4.0-cuda-12.1-python-3.11
+            command: ["python", "-c", "print('RHOAI 2.4 test')"]
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+EOF
+
+# Test 3: Custom image
+cat <<EOF | kubectl apply -f -
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: test-custom
+  namespace: $NAMESPACE
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: docker.io/pytorch/pytorch:latest
+            command: ["python", "-c", "print('Custom image test')"]
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+EOF
+
+echo "✓ Created 3 test jobs"
+
+# Wait for metrics
+echo ""
+echo "→ Waiting 20 seconds for metrics to be recorded..."
+sleep 20
+
+# Port forward to metrics endpoint
+echo "→ Fetching metrics..."
+kubectl port-forward -n $NAMESPACE svc/training-operator 8443:8443 &
+PF_PID=$!
+sleep 3
+
+# Fetch metrics
+curl -sk https://localhost:8443/metrics > /tmp/kfto_metrics.txt 2>/dev/null || {
+    echo "✗ Failed to fetch metrics"
+    kill $PF_PID 2>/dev/null
+    exit 1
+}
+
+kill $PF_PID 2>/dev/null
+
+# Verify PRIMARY metric exists
+echo ""
+echo "Phase 1 Metric Verification"
+echo "---------------------------"
+
+if grep -q "^training_jobs_total{" /tmp/kfto_metrics.txt; then
+    echo "✓ PRIMARY metric 'training_jobs_total' found"
+    
+    # Show metric values
+    echo ""
+    echo "Metric values:"
+    grep "^training_jobs_total{" /tmp/kfto_metrics.txt | while read line; do
+        echo "  $line"
+    done
+else
+    echo "✗ PRIMARY metric 'training_jobs_total' NOT FOUND"
+    exit 1
+fi
+
+# Verify cardinality
+echo ""
+echo "Cardinality Check"
+echo "-----------------"
+SERIES_COUNT=$(grep "^training_jobs_total{" /tmp/kfto_metrics.txt | wc -l)
+echo "→ Total series: $SERIES_COUNT"
+
+if [ $SERIES_COUNT -le 10 ]; then
+    echo "✓ PASS: Cardinality within limit ($SERIES_COUNT ≤ 10)"
+else
+    echo "✗ FAIL: Cardinality exceeds limit ($SERIES_COUNT > 10)"
+    exit 1
+fi
+
+# Verify expected labels
+echo ""
+echo "Label Verification"
+echo "------------------"
+
+# Check image_type labels
+if grep -q 'image_type="rhoai"' /tmp/kfto_metrics.txt; then
+    echo "✓ Found image_type='rhoai' label"
+else
+    echo "⚠ Missing image_type='rhoai' label"
+fi
+
+if grep -q 'image_type="custom"' /tmp/kfto_metrics.txt; then
+    echo "✓ Found image_type='custom' label"
+else
+    echo "⚠ Missing image_type='custom' label"
+fi
+
+# Check runtime_version labels
+FOUND_VERSIONS=""
+for version in "2.5" "2.4" "other"; do
+    if grep -q "runtime_version=\"$version\"" /tmp/kfto_metrics.txt; then
+        echo "✓ Found runtime_version='$version' label"
+        FOUND_VERSIONS="$FOUND_VERSIONS $version"
+    fi
+done
+
+# Verify legacy metrics still exist
+echo ""
+echo "Legacy Metric Compatibility"
+echo "---------------------------"
+if grep -q "training_operator_jobs_created_total" /tmp/kfto_metrics.txt; then
+    echo "✓ Legacy metrics preserved"
+else
+    echo "⚠ Legacy metrics missing"
+fi
+
+# Clean up
+echo ""
+echo "→ Cleaning up test resources..."
+kubectl delete pytorchjob test-rhoai-25 test-rhoai-24 test-custom -n $NAMESPACE --ignore-not-found=true 2>/dev/null
+
+echo ""
+echo "================================"
+echo "✓ Phase 1 Test Complete!"
+echo "================================"
+echo ""
+echo "Summary:"
+echo "- PRIMARY metric 'training_jobs_total' is working"
+echo "- Cardinality is within limits (≤10 series)"
+echo "- Image classification: RHOAI vs custom"
+echo "- Runtime version detection: 2.5, 2.4, other"
+echo "- Legacy metrics preserved for compatibility"
+echo "- Metrics secured with kube-rbac-proxy"


### PR DESCRIPTION
RHOAI Telemetry P1 Training Jobs Usage Metrics

THIS IS A DRAFT PR, UNFINISHED AND INCOMPLETE.

Summary
Implements basic telemetry collection for Training Operator usage analytics, focused on image classification and runtime version tracking with strict cardinality controls.

Key Changes
Core Telemetry Implementation:
- Primary metric: training_jobs_total{image_type, runtime_version} - tracks PyTorchJob creation by image source and PyTorch version
- Image classification: Distinguishes RHOAI images (quay.io/rhoai/, quay.io/modh/) from custom images
- Runtime detection: Extracts PyTorch versions (2.5, 2.4, 2.3, 2.2, other) from container images
- Cardinality limit: ≤10 total time series enforced via ServiceMonitor filters

Security & Infrastructure:
- kube-rbac-proxy sidecar: Secures metrics endpoint with HTTPS on port 8443
- OpenTelemetry Collector: Deploys 2-replica OTEL collector for metrics aggregation and export
- NetworkPolicy: Restricts access to monitoring namespaces only
- ServiceMonitor: Enables Prometheus scraping with metric filtering

Files Added/Modified:
- pkg/common/telemetry/{classifier,collectors,metrics}.go - Core telemetry logic
- manifests/rhoai/telemetry/ - Complete telemetry infrastructure (ServiceMonitor, OTEL collector, NetworkPolicy)
- manifests/rhoai/telemetry_patch.yaml - Deployment patches for sidecar and env vars
- scripts/test_telemetry.sh - Comprehensive test suite
- pkg/common/metrics.go - Preserves legacy metrics while adding new telemetry initialization

Environment Controls:
- TELEMETRY_ENABLED=true - Enables collection
- RECORDING_RULES_ENABLED=true - Enables Prometheus recording rules
- Graceful degradation when telemetry is disabled

Testing
- Creates test PyTorchJobs with different image types (RHOAI vs custom)
- Validates metric cardinality and labels
- Verifies secure metrics endpoint functionality
- Confirms legacy metrics compatibility

P1:
- Single primary metric with bounded cardinality
- Image source classification (RHOAI vs custom)
- Runtime version detection
- Secure collection infrastructure
- Zero performance impact when disabled

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced opt-in telemetry for the Training Operator with a TLS-secured metrics endpoint on port 8443.
  * Added Prometheus ServiceMonitor and recording rules for training job metrics with image_type and runtime_version labels.
  * Deployed an OpenTelemetry Collector to scrape, enrich, and export metrics.
  * Secured metrics access with network policies and RBAC limited to monitoring components.

* **Tests**
  * Added an end-to-end script to validate telemetry metrics, labels, cardinality, legacy metric presence, and secure access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->