### PR TITLE
Convert checkpointing annotations to env vars

### DIFF
--- a/pkg/controller.v1/pytorch/envvar_test.go
+++ b/pkg/controller.v1/pytorch/envvar_test.go
@@ -1,0 +1,113 @@
+// Copyright 2023 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pytorch
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+)
+
+func TestSetPodEnv(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// Prepare a base PyTorchJob.
+	pytorchjob := &kubeflowv1.PyTorchJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-job",
+			Annotations: map[string]string{
+				"checkpoint.config.kubeflow.org/existing-var": "new-value",
+				"checkpoint.config.kubeflow.org/new-var":      "new-value",
+			},
+		},
+		Spec: kubeflowv1.PyTorchJobSpec{
+			PyTorchReplicaSpecs: map[kubeflowv1.ReplicaType]*kubeflowv1.ReplicaSpec{
+				kubeflowv1.PyTorchJobReplicaTypeMaster: {
+					Replicas: func(i int32) *int32 { return &i }(1),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "pytorch",
+								Ports: []corev1.ContainerPort{{
+									Name:          "pytorchjob-port",
+									ContainerPort: 23456,
+								}},
+							}},
+						},
+					},
+				},
+				kubeflowv1.PyTorchJobReplicaTypeWorker: {
+					Replicas: func(i int32) *int32 { return &i }(1),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "pytorch",
+								Ports: []corev1.ContainerPort{{
+									Name:          "pytorchjob-port",
+									ContainerPort: 23456,
+								}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Case 1: An environment variable from a checkpoint annotation already exists.
+	podTemplateSpecWithExistingEnv := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Env: []corev1.EnvVar{
+						{Name: "EXISTING_VAR", Value: "original-value"},
+					},
+				},
+			},
+		},
+	}
+
+	err := setPodEnv(pytorchjob, podTemplateSpecWithExistingEnv, "master", "0")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Verify that the existing variable was not overwritten and the new one was added.
+	g.Expect(podTemplateSpecWithExistingEnv.Spec.Containers[0].Env).To(gomega.ContainElement(corev1.EnvVar{Name: "EXISTING_VAR", Value: "original-value"}))
+	g.Expect(podTemplateSpecWithExistingEnv.Spec.Containers[0].Env).To(gomega.ContainElement(corev1.EnvVar{Name: "NEW_VAR", Value: "new-value"}))
+
+	// Case 2: No conflicting environment variables.
+	podTemplateSpecNew := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "pytorch",
+				Ports: []corev1.ContainerPort{{
+					Name:          "pytorchjob-port",
+					ContainerPort: 23456,
+				}},
+			}},
+		},
+	}
+	err = setPodEnv(pytorchjob, podTemplateSpecNew, "master", "0")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Verify that the new variable was added.
+	g.Expect(podTemplateSpecNew.Spec.Containers[0].Env).To(gomega.ContainElement(corev1.EnvVar{Name: "NEW_VAR", Value: "new-value"}))
+
+	// Case 3: Check for default env vars like PYTHONUNBUFFERED.
+	g.Expect(podTemplateSpecNew.Spec.Containers[0].Env).To(gomega.ContainElement(corev1.EnvVar{Name: "PYTHONUNBUFFERED", Value: "1"}))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjustment of https://github.com/opendatahub-io/training-operator/pull/72 to avoid possibility to have multiple env variables  with same key.
When I think about it, considering whether to make it more generic (i.e. having annotation `env.config.kubeflow.org/` to support any env variable), though that would lose direct name coupling with checkpointing.
@astefanutti WDYT?

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Injects checkpoint-related environment variables from job annotations, preserving existing values and adding normalized new ones.
  * Handles missing annotations gracefully to avoid errors during env var injection.
  * Ensures PYTHONUNBUFFERED=1 is present when absent for consistent output behavior.
  * Automatically sets distributed training variables (e.g., WORLD_SIZE, RANK) based on role and replica index.

* Tests
  * Added tests validating env var merging, annotation-driven injection, and default variable handling across master and worker templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->