### PR TITLE
CARRY: Allowing job progress to be reported in the PyTorchJob CR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,14 +48,17 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240827171923-fa2c70bbbfe5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/moby/spdystream v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -46,6 +48,8 @@ github.com/google/pprof v0.0.0-20240827171923-fa2c70bbbfe5 h1:5iH8iuqE5apketRbSF
 github.com/google/pprof v0.0.0-20240827171923-fa2c70bbbfe5/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -64,6 +68,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=
+github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -71,6 +77,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo=
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -8292,9 +8292,9 @@ spec:
               Read-only (modified by the system).
             properties:
               completionPercentage:
-                description: CompletionPercentage is the percentage of the job that
-                  has completed from 0.0 to 100.0, formatted as a string with one
-                  decimal place (e.g., "45.2").
+                description: |-
+                  CompletionPercentage is the percentage of the job that has completed from 0.0 to 100.0,
+                  formatted as a string with one decimal place (e.g., "45.2").
                 type: string
               completionTime:
                 description: |-

--- a/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/manifests/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -8291,6 +8291,11 @@ spec:
               Most recently observed status of the PyTorchJob.
               Read-only (modified by the system).
             properties:
+              completionPercentage:
+                description: CompletionPercentage is the percentage of the job that
+                  has completed from 0.0 to 100.0, formatted as a string with one
+                  decimal place (e.g., "45.2").
+                type: string
               completionTime:
                 description: |-
                   Represents time when the job was completed. It is not guaranteed to

--- a/pkg/apis/kubeflow.org/v1/common_types.go
+++ b/pkg/apis/kubeflow.org/v1/common_types.go
@@ -66,6 +66,10 @@ type JobStatus struct {
 	// be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.
 	LastReconcileTime *metav1.Time `json:"lastReconcileTime,omitempty"`
+
+	// CompletionPercentage is the percentage of the job that has completed from 0.0 to 100.0,
+	// formatted as a string with one decimal place (e.g., "45.2").
+	CompletionPercentage string `json:"completionPercentage,omitempty"`
 }
 
 // ReplicaType represents the type of the replica. Each operator needs to define its

--- a/pkg/apis/kubeflow.org/v1/zz_generated.openapi.go
+++ b/pkg/apis/kubeflow.org/v1/zz_generated.openapi.go
@@ -404,6 +404,13 @@ func schema_pkg_apis_kubefloworg_v1_JobStatus(ref common.ReferenceCallback) comm
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"completionPercentage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CompletionPercentage is the percentage of the job that has completed from 0.0 to 100.0, formatted as a string with one decimal place (e.g., \"45.2\").",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/client/applyconfiguration/kubeflow.org/v1/jobstatus.go
+++ b/pkg/client/applyconfiguration/kubeflow.org/v1/jobstatus.go
@@ -24,11 +24,12 @@ import (
 // JobStatusApplyConfiguration represents a declarative configuration of the JobStatus type for use
 // with apply.
 type JobStatusApplyConfiguration struct {
-	Conditions        []JobConditionApplyConfiguration                           `json:"conditions,omitempty"`
-	ReplicaStatuses   map[kubefloworgv1.ReplicaType]*kubefloworgv1.ReplicaStatus `json:"replicaStatuses,omitempty"`
-	StartTime         *metav1.Time                                               `json:"startTime,omitempty"`
-	CompletionTime    *metav1.Time                                               `json:"completionTime,omitempty"`
-	LastReconcileTime *metav1.Time                                               `json:"lastReconcileTime,omitempty"`
+	Conditions           []JobConditionApplyConfiguration                           `json:"conditions,omitempty"`
+	ReplicaStatuses      map[kubefloworgv1.ReplicaType]*kubefloworgv1.ReplicaStatus `json:"replicaStatuses,omitempty"`
+	StartTime            *metav1.Time                                               `json:"startTime,omitempty"`
+	CompletionTime       *metav1.Time                                               `json:"completionTime,omitempty"`
+	LastReconcileTime    *metav1.Time                                               `json:"lastReconcileTime,omitempty"`
+	CompletionPercentage *string                                                    `json:"completionPercentage,omitempty"`
 }
 
 // JobStatusApplyConfiguration constructs a declarative configuration of the JobStatus type for use with
@@ -85,5 +86,13 @@ func (b *JobStatusApplyConfiguration) WithCompletionTime(value metav1.Time) *Job
 // If called multiple times, the LastReconcileTime field is set to the value of the last call.
 func (b *JobStatusApplyConfiguration) WithLastReconcileTime(value metav1.Time) *JobStatusApplyConfiguration {
 	b.LastReconcileTime = &value
+	return b
+}
+
+// WithCompletionPercentage sets the CompletionPercentage field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CompletionPercentage field is set to the value of the last call.
+func (b *JobStatusApplyConfiguration) WithCompletionPercentage(value string) *JobStatusApplyConfiguration {
+	b.CompletionPercentage = &value
 	return b
 }

--- a/pkg/controller.v1/pytorch/envvar.go
+++ b/pkg/controller.v1/pytorch/envvar.go
@@ -121,6 +121,12 @@ func setPodEnv(obj interface{}, podTemplateSpec *corev1.PodTemplateSpec, rtype, 
 					Value: strconv.Itoa(int(totalReplicas)),
 				})
 		}
+
+		// Set the training progress file path.
+		podTemplateSpec.Spec.Containers[i].Env = append(podTemplateSpec.Spec.Containers[i].Env, corev1.EnvVar{
+			Name:  EnvTrainingProgressFilePath,
+			Value: GetProgressFilePath(pytorchjob),
+		})
 	}
 
 	return nil

--- a/pkg/controller.v1/pytorch/training_info.go
+++ b/pkg/controller.v1/pytorch/training_info.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+package pytorch
+
+import (
+	"fmt"
+
+	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+)
+
+const (
+	// EnvTrainingProgressFilePath is the environment variable name for the training progress file path.
+	EnvTrainingProgressFilePath = "TRAINING_PROGRESS_FILE_PATH"
+)
+
+func GetProgressFilePath(job *kubeflowv1.PyTorchJob) string {
+	return fmt.Sprintf("/tmp/training_data/%s/progress.json", job.Name)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of https://github.com/opendatahub-io/training-operator/pull/74, storing progress file into temp folder (available by default).
Trainer callback needs to retrieve progress file path from env variable `TRAINING_PROGRESS_FILE_PATH`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Job status gains completionPercentage (string, 0.0–100.0 with one decimal) across PyTorchJob, TFJob, MPIJob, JAXJob, PaddleJob, XGBoostJob and shared JobStatus.
  - PyTorchJob controller polls rank-0 pod progress, updates status.completionPercentage periodically.
  - Training containers receive an env var pointing to the progress JSON file path.

- **Chores**
  - Added indirect dependencies to support pod exec/streaming operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->