### PR TITLE
PR check fix

### DIFF
--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -11,3 +11,5 @@ secretGenerator:
   - name: training-operator-webhook-cert
     options:
       disableNameSuffixHash: true
+
+namePrefix: kubeflow-

--- a/scripts/gha/setup-training-operator.sh
+++ b/scripts/gha/setup-training-operator.sh
@@ -40,14 +40,14 @@ if [ "${GANG_SCHEDULER_NAME}" = "scheduler-plugins" ]; then
     --set scheduler.image="registry.k8s.io/scheduler-plugins/kube-scheduler:${SCHEDULER_PLUGINS_VERSION}"
 
   echo "Configure gang-scheduling using scheduler-plugins to training-operator"
-  kubectl patch -n kubeflow deployments training-operator --type='json' \
+  kubectl patch -n kubeflow deployments kubeflow-training-operator --type='json' \
     -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/1", "value": "--gang-scheduler-name=scheduler-plugins"}]'
 elif  [ "${GANG_SCHEDULER_NAME}" = "volcano" ]; then
   VOLCANO_SCHEDULER_VERSION=$(go list -m -f "{{.Version}}" volcano.sh/apis)
 
   # patch scheduler first so that it is ready when scheduler-deployment installing finished
   echo "Configure gang-scheduling using volcano to training-operator"
-  kubectl patch -n kubeflow deployments training-operator --type='json' \
+  kubectl patch -n kubeflow deployments kubeflow-training-operator --type='json' \
     -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/1", "value": "--gang-scheduler-name=volcano"}]'
 
   echo "Installing volcano scheduler ${VOLCANO_SCHEDULER_VERSION}..."
@@ -55,7 +55,7 @@ elif  [ "${GANG_SCHEDULER_NAME}" = "volcano" ]; then
 fi
 
 TIMEOUT=30
-until kubectl get pods -n kubeflow | grep training-operator | grep 1/1 || [[ $TIMEOUT -eq 1 ]]; do
+until kubectl get pods -n kubeflow | grep kubeflow-training-operator | grep 1/1 || [[ $TIMEOUT -eq 1 ]]; do
   sleep 10
   TIMEOUT=$(( TIMEOUT - 1 ))
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied a consistent name prefix to resources generated by the standalone overlay; all created Kubernetes objects will now include the kubeflow- prefix.
  * Updated setup scripts to target and wait for the renamed training operator (kubeflow-training-operator) during installation flows.
  * Impact: Resource names and installer behavior change on next apply/run; scripts, dashboards, alerts, or tooling that rely on exact names may need updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->