### PR TITLE
Upgrade go version to 1.25

### DIFF
--- a/build/images/training-operator/Dockerfile
+++ b/build/images/training-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/build/images/training-operator/Dockerfile.rhoai
+++ b/build/images/training-operator/Dockerfile.rhoai
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kubeflow/training-operator
 
-go 1.23
+go 1.25
 
-toolchain go1.23.2
+toolchain go1.25.7
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade go version to 1.25

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go language and toolchain versions to v1.25 across build configurations and Docker images, enabling compatibility with the latest Go runtime and build improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->