### PR TITLE
Restrict secrets RBAC to namespace-scoped Role

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - ./rbac/cluster-role-binding.yaml
   - ./rbac/role.yaml
   - ./rbac/service-account.yaml
+  - ./rbac/webhook-secret-role.yaml
+  - ./rbac/webhook-secret-role-binding.yaml
   - ./webhook
   - service.yaml
   - deployment.yaml

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -46,15 +46,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   verbs:
   - create

--- a/manifests/base/rbac/webhook-secret-role-binding.yaml
+++ b/manifests/base/rbac/webhook-secret-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: training-operator
+  name: training-operator-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: training-operator-webhook
+subjects:
+- kind: ServiceAccount
+  name: training-operator

--- a/manifests/base/rbac/webhook-secret-role.yaml
+++ b/manifests/base/rbac/webhook-secret-role.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: training-operator
+  name: training-operator-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -38,7 +38,8 @@ type Config struct {
 	WebhookConfigurationName string
 }
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
+// Note: Secrets access is handled via a namespace-scoped Role (not ClusterRole) to limit
+// permissions to the operator's own namespace only. See manifests/base/rbac/webhook-secret-role.yaml.
 //+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
 
 // ManageCerts creates all certs for webhooks.


### PR DESCRIPTION
**What this PR does / why we need it**:
Restrict secrets RBAC to namespace-scoped Role

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined permissions structure to restrict secrets access to a dedicated, namespace-scoped role for improved security isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->