### PR TITLE
feat: integrate with cluster TLS security profile

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -17,16 +17,21 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,6 +39,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -73,6 +79,142 @@ func init() {
 	utilruntime.Must(v1beta1.AddToScheme(scheme))
 	utilruntime.Must(schedulerpluginsv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
+}
+
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,resourceNames=cluster,verbs=get
+
+func fetchTLSOpts(cfg *restclient.Config) []func(*tls.Config) {
+	var tlsOpts []func(*tls.Config)
+	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer bootstrapCancel()
+	bootstrapClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Info("Failed to create bootstrap client for TLS profile, using hardened defaults")
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			c.MinVersion = tls.VersionTLS12
+			c.NextProtos = []string{"h2", "http/1.1"}
+		})
+		return tlsOpts
+	}
+
+	apiServer := &unstructured.Unstructured{}
+	apiServer.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "APIServer",
+	})
+	if err := bootstrapClient.Get(bootstrapCtx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			setupLog.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
+			tlsOpts = append(tlsOpts, func(c *tls.Config) {
+				c.MinVersion = tls.VersionTLS12
+				c.CipherSuites = intermediateCiphers
+			})
+		} else {
+			setupLog.Error(err, "Failed to read APIServer TLS profile, operator cannot start without TLS policy")
+			os.Exit(1)
+		}
+	} else {
+		minVersion, ciphers := parseTLSProfile(apiServer)
+		if ciphers != nil && len(ciphers) == 0 {
+			setupLog.Error(nil, "Custom TLS profile specified ciphers but none are supported by Go, "+
+				"refusing to start with unrestricted ciphers")
+			os.Exit(1)
+		}
+		setupLog.Info("Applying cluster TLS profile", "minVersion", minVersion, "ciphers", len(ciphers))
+		tlsOpts = append(tlsOpts, func(c *tls.Config) {
+			c.MinVersion = minVersion
+			if len(ciphers) > 0 {
+				c.CipherSuites = ciphers
+			}
+		})
+	}
+	tlsOpts = append(tlsOpts, func(c *tls.Config) {
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
+	return tlsOpts
+}
+
+var tlsVersionMap = map[string]uint16{
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+var openSSLToGoCipher = map[string]uint16{
+	"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-GCM-SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+}
+
+// Intermediate profile defaults (used when profile is nil, empty, or Intermediate)
+var intermediateMinVersion uint16 = tls.VersionTLS12
+var intermediateCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+func parseTLSProfile(apiServer *unstructured.Unstructured) (uint16, []uint16) {
+	profile, found, err := unstructured.NestedMap(apiServer.Object, "spec", "tlsSecurityProfile")
+	if err != nil {
+		setupLog.Error(err, "Failed to read tlsSecurityProfile from APIServer, using Intermediate defaults")
+		return intermediateMinVersion, intermediateCiphers
+	}
+	if !found || profile == nil {
+		return intermediateMinVersion, intermediateCiphers
+	}
+
+	profileType, _ := profile["type"].(string)
+	switch profileType {
+	case "Intermediate", "":
+		return intermediateMinVersion, intermediateCiphers
+	case "Custom":
+		custom, _, err := unstructured.NestedMap(profile, "custom")
+		if err != nil {
+			setupLog.Error(err, "Failed to read custom TLS profile, using Intermediate defaults")
+			return intermediateMinVersion, intermediateCiphers
+		}
+		if custom == nil {
+			setupLog.Info("Custom TLS profile type set but no custom block provided, using Intermediate defaults")
+			return intermediateMinVersion, intermediateCiphers
+		}
+		minVer, _ := custom["minTLSVersion"].(string)
+		minVersion := tlsVersionMap[minVer]
+		if minVersion == 0 {
+			minVersion = tls.VersionTLS12
+		}
+		cipherNames, _, err := unstructured.NestedStringSlice(custom, "ciphers")
+		if err != nil {
+			setupLog.Error(err, "Failed to read ciphers from custom TLS profile, proceeding without cipher restrictions")
+		}
+		ciphers := make([]uint16, 0, len(cipherNames))
+		for _, name := range cipherNames {
+			if id, ok := openSSLToGoCipher[name]; ok {
+				ciphers = append(ciphers, id)
+			} else {
+				setupLog.Info("Cipher from TLS profile not supported by Go, skipping", "cipher", name)
+			}
+		}
+		return minVersion, ciphers
+	case "Modern":
+		return tls.VersionTLS13, nil
+	case "Old":
+		return tls.VersionTLS12, nil
+	default:
+		setupLog.Info("Unrecognized TLS profile type, using Intermediate defaults", "profileType", profileType)
+		return intermediateMinVersion, intermediateCiphers
+	}
 }
 
 // newCacheOptions builds cache options with label selectors to restrict informer
@@ -175,13 +317,17 @@ func main() {
 	cfg := ctrl.GetConfigOrDie()
 	cfg.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(clientQps), clientBurst)
 
+	tlsOpts := fetchTLSOpts(cfg)
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
+			TLSOpts:     tlsOpts,
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: webhookServerPort,
+			Port:    webhookServerPort,
+			TLSOpts: tlsOpts,
 		}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,

--- a/cmd/training-operator.v1/tls_test.go
+++ b/cmd/training-operator.v1/tls_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeAPIServer(spec map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(apiServerGVK())
+	if spec != nil {
+		obj.Object["spec"] = spec
+	}
+	return obj
+}
+
+func apiServerGVK() (gvk struct {
+	Group, Version, Kind string
+}) {
+	return struct{ Group, Version, Kind string }{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "APIServer",
+	}
+}
+
+func TestParseTLSProfile(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiServer      *unstructured.Unstructured
+		wantMinVersion uint16
+		wantCiphers    []uint16
+	}{
+		{
+			name:           "nil profile returns Intermediate defaults",
+			apiServer:      makeAPIServer(nil),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name:           "missing tlsSecurityProfile returns Intermediate defaults",
+			apiServer:      makeAPIServer(map[string]interface{}{}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "Intermediate profile returns Intermediate defaults",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Intermediate",
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "empty profile type returns Intermediate defaults",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "",
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "Modern returns TLS 1.3 with nil ciphers",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Modern",
+				},
+			}),
+			wantMinVersion: tls.VersionTLS13,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Old returns TLS 1.2 with nil ciphers",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Old",
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Custom with valid ciphers",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+					"custom": map[string]interface{}{
+						"minTLSVersion": "VersionTLS13",
+						"ciphers": []interface{}{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			}),
+			wantMinVersion: tls.VersionTLS13,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			},
+		},
+		{
+			name: "Custom with DHE cipher logs and skips unsupported",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+					"custom": map[string]interface{}{
+						"minTLSVersion": "VersionTLS12",
+						"ciphers": []interface{}{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			},
+		},
+		{
+			name: "Custom with nil custom block returns Intermediate defaults",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "Custom with unknown minTLSVersion falls back to TLS 1.2",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+					"custom": map[string]interface{}{
+						"minTLSVersion": "VersionTLS11",
+						"ciphers": []interface{}{
+							"ECDHE-RSA-AES128-GCM-SHA256",
+						},
+					},
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			},
+		},
+		{
+			name: "unknown profile type returns Intermediate defaults",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Futuristic",
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "Custom with all unsupported ciphers returns empty slice",
+			apiServer: makeAPIServer(map[string]interface{}{
+				"tlsSecurityProfile": map[string]interface{}{
+					"type": "Custom",
+					"custom": map[string]interface{}{
+						"minTLSVersion": "VersionTLS12",
+						"ciphers": []interface{}{
+							"DHE-RSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			}),
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMinVersion, gotCiphers := parseTLSProfile(tt.apiServer)
+
+			if gotMinVersion != tt.wantMinVersion {
+				t.Errorf("minVersion = 0x%04x, want 0x%04x", gotMinVersion, tt.wantMinVersion)
+			}
+
+			if tt.wantCiphers == nil {
+				if gotCiphers != nil {
+					t.Errorf("ciphers = %v, want nil", gotCiphers)
+				}
+				return
+			}
+
+			if gotCiphers == nil {
+				t.Fatal("expected non-nil empty slice, got nil (fail-closed guard needs non-nil)")
+			}
+			if len(gotCiphers) != len(tt.wantCiphers) {
+				t.Fatalf("ciphers length = %d, want %d", len(gotCiphers), len(tt.wantCiphers))
+			}
+			for i, c := range gotCiphers {
+				if c != tt.wantCiphers[i] {
+					t.Errorf("ciphers[%d] = 0x%04x, want 0x%04x", i, c, tt.wantCiphers[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTLSVersionMap(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want uint16
+	}{
+		{name: "TLS 1.2", key: "VersionTLS12", want: tls.VersionTLS12},
+		{name: "TLS 1.3", key: "VersionTLS13", want: tls.VersionTLS13},
+		{name: "unknown version returns zero", key: "VersionTLS11", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tlsVersionMap[tt.key]
+			if got != tt.want {
+				t.Errorf("tlsVersionMap[%q] = 0x%04x, want 0x%04x", tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -282,6 +282,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  resourceNames:
+  - cluster
+  verbs:
+  - get
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies


### PR DESCRIPTION
## Summary
- Fetch the cluster APIServer TLS profile at startup (OpenShift only, soft error on non-OpenShift)
- Apply profile-driven cipher suites and TLS version to webhook and metrics servers
- Set explicit `MinVersion=TLS12` fallback for non-OpenShift clusters (defense-in-depth)
- Set NextProtos (ALPN) for HTTP/2 support on all TLS endpoints
- Add RBAC for `config.openshift.io/apiservers`

### Approach: zero new dependencies
Uses unstructured access to the APIServer CR instead of `openshift/api` typed imports to avoid dependency cascades on this legacy codebase (v1 API, deprecated in RHOAI 3.6). No `go.mod` changes, only `main.go` modified.

No SecurityProfileWatcher (profile changes require operator restart via Deployment rollout, acceptable for a deprecated component).

[RHOAIENG-67676](https://redhat.atlassian.net/browse/RHOAIENG-67676)

## Test plan
- [x] `go build ./...` passes
- [x] `gofmt` clean
- [x] No dependency changes
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically configures TLS settings for both metrics and webhook endpoints using the cluster’s OpenShift TLS security profile.
  * If the profile is missing or can’t be retrieved, falls back to hardened TLS defaults.
  * Applies cipher suite and minimum TLS version choices based on the supported profile type.
* **Security / RBAC**
  * Added RBAC permissions to read the OpenShift API server TLS security profile (get `apiservers` for `cluster`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->