### PR TITLE
docs: add AI scaffolding tier 2 pattern references and architecture

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [[ \"$TOOL_INPUT\" == *\".go\"* ]]; then filepath=$(echo \"$TOOL_INPUT\" | grep -oE '\"[^\"]*\\.go\"' | head -1 | tr -d '\"'); [ -n \"$filepath\" ] && [ -f \"$filepath\" ] && gofmt -w \"$filepath\"; fi"
+          },
+          {
+            "type": "command",
+            "command": "if [[ \"$TOOL_INPUT\" == *\".py\"* ]]; then filepath=$(echo \"$TOOL_INPUT\" | grep -oE '\"[^\"]*\\.py\"' | head -1 | tr -d '\"'); [ -n \"$filepath\" ] && [ -f \"$filepath\" ] && black --quiet \"$filepath\" 2>/dev/null; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-new-job-type/SKILL.md
+++ b/.claude/skills/add-new-job-type/SKILL.md
@@ -1,0 +1,158 @@
+# Add a New Distributed Job Type
+
+Use this skill when adding support for a new distributed training framework (like JAX, PyTorch, TensorFlow).
+JAXJob is the most recently added job type — use it as the primary reference.
+
+## Files to Create
+
+### 1. CRD Type Definition — `pkg/apis/kubeflow.org/v1/<framework>_types.go`
+
+Define three structs and constants. Follow the marker pattern exactly:
+
+```go
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=newjobs
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+type NewJob struct { ... }
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=newjobs
+//+kubebuilder:object:root=true
+type NewJobList struct { ... }
+```
+
+Required constants (see `jax_types.go` for naming):
+
+| Constant | Example Value |
+|----------|---------------|
+| `NewJobDefaultPortName` | `"newjob-port"` |
+| `NewJobDefaultContainerName` | `"newjob"` |
+| `NewJobDefaultPort` | `12345` |
+| `NewJobDefaultRestartPolicy` | `RestartPolicyNever` |
+| `NewJobKind` | `"NewJob"` |
+| `NewJobPlural` | `"newjobs"` |
+| `NewJobSingular` | `"newjob"` |
+| `NewJobFrameworkName` | `"newjob"` |
+| `NewJobReplicaTypeWorker` | `ReplicaType("Worker")` |
+
+The `init()` function must register both the types and the defaulting functions:
+
+```go
+func init() {
+    SchemeBuilder.Register(&NewJob{}, &NewJobList{})
+    SchemeBuilder.SchemeBuilder.Register(addNewJobDefaultingFuncs)
+}
+```
+
+### 2. Defaults — `pkg/apis/kubeflow.org/v1/<framework>_defaults.go`
+
+Implement `SetDefaults_NewJob()` using helpers from `defaulting_utils.go`:
+- `setDefaultPort()`, `setDefaultRestartPolicy()`, `setDefaultReplicas()`, `setTypeNameToCamelCase()`
+
+Reference: `jax_defaults.go`
+
+### 3. Controller — `pkg/controller.v1/<framework>/`
+
+Create at minimum:
+
+- **`<framework>_controller.go`**: Reconciler struct embedding `common.JobController`, implementing all methods of `common.ControllerInterface` (defined in `pkg/common/interface.go`). Key methods:
+  - `NewReconciler()` — factory function
+  - `Reconcile()` — main reconciliation entry point
+  - `SetupWithManager()` — register watches for the job CRD, owned Pods, Services, and PodGroups
+  - `SetClusterSpec()` — inject framework-specific env vars into pod templates
+  - `IsMasterRole()` — identify the master replica
+  - `UpdateJobStatus()` — update conditions and replica statuses
+
+  Add RBAC markers:
+  ```go
+  //+kubebuilder:rbac:groups=kubeflow.org,resources=newjobs,verbs=get;list;watch;create;update;patch;delete
+  //+kubebuilder:rbac:groups=kubeflow.org,resources=newjobs/status,verbs=get;update;patch
+  //+kubebuilder:rbac:groups=kubeflow.org,resources=newjobs/finalizers,verbs=update
+  ```
+
+- **`envvar.go`**: Framework-specific environment variable setup (coordinator address, rank, world size, etc.)
+
+- **Tests**: `<framework>_controller_test.go`, `<framework>_controller_suite_test.go`, `envvar_test.go`
+
+### 4. Webhook — `pkg/webhooks/<framework>/<framework>_webhook.go`
+
+Create a validating webhook with the marker:
+```go
+//+kubebuilder:webhook:path=/validate-kubeflow-org-v1-newjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=newjobs,verbs=create;update,versions=v1,name=validator.newjob.training-operator.kubeflow.org,admissionReviewVersions=v1
+```
+
+Implement `ValidateCreate`, `ValidateUpdate`, `ValidateDelete` on a `Webhook` struct. Validations should check:
+- DNS-compliant job name
+- RunPolicy fields (via `util.ValidateRunPolicy`)
+- Replica specs: correct types, container images present, default container name exists
+
+Reference: `pkg/webhooks/jax/jaxjob_webhook.go`
+
+### 5. Examples — `examples/<framework>/`
+
+Add at least one example YAML showing a minimal job spec.
+
+## Files to Update
+
+### 6. Controller Registration — `pkg/controller.v1/register_controller.go`
+
+Add import and map entry in `SupportedSchemeReconciler`:
+```go
+import newjobcontroller "github.com/kubeflow/training-operator/pkg/controller.v1/newjob"
+
+// In SupportedSchemeReconciler map:
+kubeflowv1.NewJobKind: func(mgr manager.Manager, ...) error {
+    return newjobcontroller.NewReconciler(mgr, gangSchedulingSetupFunc).SetupWithManager(mgr, controllerThreads)
+},
+```
+
+### 7. Webhook Registration — `pkg/webhooks/webhooks.go`
+
+Add import and map entry in `SupportedSchemeWebhook`:
+```go
+import "github.com/kubeflow/training-operator/pkg/webhooks/newjob"
+
+// In SupportedSchemeWebhook map:
+trainingoperator.NewJobKind: newjob.SetupWebhook,
+```
+
+### 8. Main Entrypoint — `cmd/training-operator.v1/main.go`
+
+Add the new job kind to `enabledSchemes` and scheme registration.
+
+## Code Generation (mandatory)
+
+After all hand-written files are in place:
+
+```bash
+make generate    # Generates deepcopy, defaults, OpenAPI, clients, CRD YAMLs, Python SDK
+```
+
+This produces:
+- `pkg/apis/kubeflow.org/v1/zz_generated.deepcopy.go` (updated)
+- `pkg/apis/kubeflow.org/v1/zz_generated.defaults.go` (updated)
+- `pkg/apis/kubeflow.org/v1/zz_generated.openapi.go` (updated)
+- `manifests/base/crds/kubeflow.org_newjobs.yaml` (new)
+- `manifests/base/rbac/role.yaml` (updated from RBAC markers)
+- `pkg/client/` — clientset, informers, listers, apply configurations (updated)
+- `sdk/python/kubeflow/training/models/kubeflow_org_v1_new_job*.py` (new)
+
+Never hand-edit generated files.
+
+## Python SDK Updates
+
+After `make generate`, update the hand-written SDK files:
+
+- `sdk/python/kubeflow/training/constants/constants.py` — add entry to `JOB_PARAMETERS` dict and `REPLICA_TYPES`
+- `sdk/python/kubeflow/training/constants/constants.py` — add to `JOB_MODELS_TYPE` union
+
+## Verification
+
+```bash
+make testall                    # Full suite: generate + fmt + vet + lint + test
+go test ./pkg/controller.v1/<framework>/...   # Controller unit tests
+```

--- a/.claude/skills/add-sdk-method/SKILL.md
+++ b/.claude/skills/add-sdk-method/SKILL.md
@@ -1,0 +1,157 @@
+# Add a New Python SDK Method
+
+Use this skill when adding a new method to the `TrainingClient` Python SDK.
+
+## Architecture
+
+The SDK has two layers:
+- **Generated layer** (`sdk/python/kubeflow/training/models/`) — OpenAPI-generated model classes from Go types. Never hand-edit.
+- **Hand-written layer** — the high-level client, constants, and utilities:
+  - `sdk/python/kubeflow/training/api/training_client.py` — main `TrainingClient` class
+  - `sdk/python/kubeflow/training/constants/constants.py` — job type registry and constants
+  - `sdk/python/kubeflow/training/utils/utils.py` — helper functions
+
+## Step 1: Add the Method to `TrainingClient`
+
+File: `sdk/python/kubeflow/training/api/training_client.py`
+
+Follow the existing method pattern:
+
+```python
+def new_method(
+    self,
+    name: str,
+    namespace: Optional[str] = None,
+    job_kind: Optional[str] = None,
+    timeout: int = constants.DEFAULT_TIMEOUT,
+) -> SomeReturnType:
+    """Short description of what this method does.
+
+    Args:
+        name: Name of the training job.
+        namespace: Namespace for the job. Defaults to client namespace.
+        job_kind: Job kind (e.g., PyTorchJob). Defaults to client job_kind.
+        timeout: Kubernetes API timeout in seconds.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        TimeoutError: On API timeout.
+        RuntimeError: On API errors.
+    """
+    namespace = namespace or self.namespace
+    job_kind = job_kind or self.job_kind
+
+    if job_kind not in constants.JOB_PARAMETERS:
+        raise ValueError(
+            f"Job kind must be one of {list(constants.JOB_PARAMETERS.keys())}"
+        )
+
+    try:
+        # Use self.custom_api for CRD operations
+        response = self.custom_api.get_namespaced_custom_object(
+            constants.GROUP,
+            constants.VERSION,
+            namespace,
+            constants.JOB_PARAMETERS[job_kind]["plural"],
+            name,
+            _request_timeout=timeout,
+        )
+        # Deserialize if returning a model object
+        return self.api_client.deserialize(
+            response, constants.JOB_PARAMETERS[job_kind]["model"]
+        )
+    except multiprocessing.TimeoutError:
+        raise TimeoutError(f"Timeout waiting for {job_kind}/{name}")
+    except client.ApiException as e:
+        raise RuntimeError(f"Failed: {e}")
+```
+
+Key conventions:
+- `namespace` and `job_kind` default to `self.namespace` / `self.job_kind`
+- Validate `job_kind` against `constants.JOB_PARAMETERS`
+- Use `self.custom_api` (`CustomObjectsApi`) for training job CRDs
+- Use `self.core_api` (`CoreV1Api`) for Pods, Services, ConfigMaps
+- Wrap API calls with `try/except` for `ApiException` and `TimeoutError`
+- Use `self.api_client.deserialize()` to convert responses to model objects
+
+## Step 2: Add Constants (if needed)
+
+File: `sdk/python/kubeflow/training/constants/constants.py`
+
+If the method introduces new constants (labels, default values, condition types):
+
+```python
+NEW_CONSTANT = "some-value"
+```
+
+If adding a new job type, add to `JOB_PARAMETERS`:
+```python
+JOB_PARAMETERS = {
+    ...
+    "NewJob": {
+        "model": "KubeflowOrgV1NewJob",
+        "plural": "newjobs",
+        "container": "newjob",
+        "base_image": "docker.io/new-framework:latest",
+    },
+}
+```
+
+And update the `JOB_MODELS_TYPE` union type and `REPLICA_TYPES` dict.
+
+## Step 3: Add Utility Functions (if needed)
+
+File: `sdk/python/kubeflow/training/utils/utils.py`
+
+For shared helpers (e.g., building pod templates, container specs).
+
+## Step 4: Update Exports
+
+File: `sdk/python/kubeflow/training/__init__.py`
+
+If you added new public classes or functions, add them to `__init__.py` imports.
+Note: most of this file is auto-generated — only the appended section at the bottom is hand-written.
+
+## Step 5: Write Tests
+
+File: `sdk/python/kubeflow/training/api/training_client_test.py`
+
+Follow the existing test pattern using `unittest.mock`:
+
+```python
+def test_new_method(self):
+    """Test the new_method functionality."""
+    # Mock the Kubernetes API
+    with patch.object(
+        self.client.custom_api,
+        "get_namespaced_custom_object",
+        return_value=mock_response,
+    ):
+        result = self.client.new_method(
+            name="test-job",
+            namespace="default",
+            job_kind="PyTorchJob",
+        )
+        self.assertEqual(result, expected_value)
+```
+
+Test cases to cover:
+- Happy path with explicit parameters
+- Default namespace/job_kind from client
+- Invalid job_kind raises `ValueError`
+- API timeout raises `TimeoutError`
+- API error raises `RuntimeError`
+
+## Verification
+
+```bash
+# Unit tests
+pytest sdk/python/kubeflow/training/api/training_client_test.py -v
+
+# Lint and format
+pre-commit run black --files sdk/python/kubeflow/training/api/training_client.py
+pre-commit run flake8 --files sdk/python/kubeflow/training/api/training_client.py
+pre-commit run isort --files sdk/python/kubeflow/training/api/training_client.py
+```

--- a/.claude/skills/update-crd/SKILL.md
+++ b/.claude/skills/update-crd/SKILL.md
@@ -1,0 +1,127 @@
+# Update an Existing CRD
+
+Use this skill when modifying CRD type definitions — adding fields, changing validation, updating defaults, or adjusting printer columns.
+
+## Identify What to Change
+
+CRD types live in `pkg/apis/kubeflow.org/v1/`. Each job type has:
+- `<framework>_types.go` — struct definitions and kubebuilder markers
+- `<framework>_defaults.go` — default value logic
+- `common_types.go` — shared types (`JobStatus`, `ReplicaSpec`, `RunPolicy`, etc.)
+
+## Step 1: Modify Type Structs
+
+Edit the relevant `_types.go` file. Key patterns:
+
+**Adding a field to a job spec:**
+```go
+type PyTorchJobSpec struct {
+    RunPolicy   RunPolicy                              `json:"runPolicy"`
+    PyTorchReplicaSpecs map[ReplicaType]*ReplicaSpec    `json:"pytorchReplicaSpecs"`
+    NewField    *string                                 `json:"newField,omitempty"`  // new
+}
+```
+
+**Adding validation via kubebuilder markers:**
+```go
+// +kubebuilder:validation:Minimum=0
+// +kubebuilder:validation:Maximum=100
+NewField *int32 `json:"newField,omitempty"`
+```
+
+**Adding a printer column:**
+```go
+//+kubebuilder:printcolumn:name="NewCol",type=string,JSONPath=`.spec.newField`
+```
+
+**Modifying shared types** (affects all job types):
+Edit `common_types.go` for changes to `RunPolicy`, `ReplicaSpec`, `JobStatus`, `SchedulingPolicy`, etc.
+
+## Step 2: Update Defaults
+
+If the new field needs a default value, edit `<framework>_defaults.go`:
+
+```go
+func SetDefaults_PyTorchJob(job *PyTorchJob) {
+    // existing defaults...
+    if job.Spec.NewField == nil {
+        defaultVal := "default"
+        job.Spec.NewField = &defaultVal
+    }
+}
+```
+
+Shared defaulting helpers are in `defaulting_utils.go`.
+
+## Step 3: Update Webhook Validation
+
+If the new field needs validation beyond kubebuilder markers, update the webhook in `pkg/webhooks/<framework>/`:
+
+```go
+func validateSpec(spec trainingoperator.PyTorchJobSpec) field.ErrorList {
+    var allErrs field.ErrorList
+    // existing validations...
+    if spec.NewField != nil && *spec.NewField == "" {
+        allErrs = append(allErrs, field.Invalid(
+            field.NewPath("spec").Child("newField"),
+            spec.NewField,
+            "must not be empty when set",
+        ))
+    }
+    return allErrs
+}
+```
+
+For immutable fields (cannot change after creation), add to `ValidateUpdate`:
+```go
+func (w *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+    oldJob := oldObj.(*trainingoperator.PyTorchJob)
+    newJob := newObj.(*trainingoperator.PyTorchJob)
+    allErrs := validatePyTorchJob(oldJob, newJob)
+    // Check immutability
+    if oldJob.Spec.NewField != newJob.Spec.NewField {
+        allErrs = append(allErrs, field.Forbidden(...))
+    }
+    return nil, allErrs.ToAggregate()
+}
+```
+
+Reference: `pkg/webhooks/tensorflow/tfjob_webhook.go` for RunPolicy immutability checks.
+
+## Step 4: Run Code Generation (mandatory)
+
+```bash
+make generate
+```
+
+This regenerates all derived artifacts:
+- `zz_generated.deepcopy.go` — DeepCopy methods for modified structs
+- `zz_generated.defaults.go` — default registration wrappers
+- `zz_generated.openapi.go` — OpenAPI schema
+- `manifests/base/crds/kubeflow.org_<plural>.yaml` — CRD YAML with updated schema
+- `pkg/client/` — clientset, informers, listers, apply configurations
+- `sdk/python/kubeflow/training/models/` — Python model classes
+
+Never hand-edit any of these files.
+
+## Step 5: Update Tests
+
+- Controller tests in `pkg/controller.v1/<framework>/` — test new field handling in reconciliation
+- Webhook tests in `pkg/webhooks/<framework>/` — test new validation rules
+- Defaults tests (if any) — verify default values are set correctly
+
+## Step 6: Backwards Compatibility
+
+- New fields should be pointers with `omitempty` JSON tags to remain optional
+- Existing fields must not change JSON tag names or types
+- If removing a field, consider deprecation first (add `// Deprecated:` comment)
+- RunPolicy changes affect all job types — test across frameworks
+
+## Verification
+
+```bash
+make testall                                          # Full suite
+go test ./pkg/controller.v1/<framework>/...           # Controller tests
+go test ./pkg/webhooks/<framework>/...                # Webhook tests (if present)
+hack/verify-codegen.sh                                # Verify generated code is current
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,115 @@
+# Architecture
+
+Kubernetes operator for distributed machine learning training jobs. Manages six framework-specific CRDs (PyTorchJob, TFJob, XGBoostJob, MPIJob, PaddleJob, JAXJob) using the `kubeflow.org/v1` API, providing pod/service lifecycle management, gang scheduling, and elastic training support.
+
+## Controller architecture
+
+```
+cmd/training-operator.v1/main.go
+  └─ controller-runtime Manager
+       ├─ Per-job reconciler (one per enabled CRD)
+       │    └─ Embeds common.JobController for shared logic
+       ├─ Per-job validating webhook
+       ├─ Cert rotation (pkg/cert/)
+       └─ Metrics, health, leader election
+```
+
+### Reconciler pattern
+
+Each job type has a reconciler in `pkg/controller.v1/<framework>/` that embeds `common.JobController` and implements `common.ControllerInterface` (defined in `pkg/common/interface.go`). The common controller handles pod/service lifecycle, expectations, status updates, and gang scheduling. Job-specific reconcilers provide:
+
+- `SetClusterSpec()` — inject framework environment variables (coordinator address, rank, world size)
+- `IsMasterRole()` — identify the master replica type
+- `UpdateJobStatus()` — map replica states to job conditions
+
+### Registration
+
+Controllers and webhooks are registered via maps in two files:
+
+| File | Map | Purpose |
+|------|-----|---------|
+| `pkg/controller.v1/register_controller.go` | `SupportedSchemeReconciler` | Maps job kind to reconciler setup function |
+| `pkg/webhooks/webhooks.go` | `SupportedSchemeWebhook` | Maps job kind to webhook setup function |
+
+`main.go` iterates enabled schemes and calls both setup functions.
+
+### Gang scheduling
+
+Pluggable via `GangSchedulingSetupFunc` — supports Volcano (`volcano.sh/v1beta1 PodGroup`) and scheduler-plugins (`scheduling.sigs.k8s.io/v1alpha1 PodGroup`). Configured via `--gang-scheduler-name` flag. The common controller syncs PodGroups based on `RunPolicy.SchedulingPolicy`.
+
+## CRD types
+
+All CRDs live in `pkg/apis/kubeflow.org/v1/`. Each job type has:
+
+| File | Content |
+|------|---------|
+| `<framework>_types.go` | Job, JobSpec, JobList structs with kubebuilder markers |
+| `<framework>_defaults.go` | `SetDefaults_<Job>()` for default ports, replicas, restart policy |
+| `common_types.go` | Shared types: `RunPolicy`, `ReplicaSpec`, `JobStatus`, `SchedulingPolicy` |
+
+### Job types and replica roles
+
+| CRD | Replica types | Framework-specific features |
+|-----|---------------|---------------------------|
+| PyTorchJob | Master, Worker | Elastic training, init containers, HPA |
+| TFJob | PS, Chief, Worker, Evaluator | Parameter server architecture |
+| MPIJob | Launcher, Worker | MPI-based distributed training |
+| XGBoostJob | Master, Worker | Gradient boosting |
+| PaddleJob | Master, Worker | PaddlePaddle framework |
+| JAXJob | Worker | JAX SPMD training |
+
+### Shared labels
+
+All pods and services created by the operator carry these labels:
+- `training.kubeflow.org/operator-name` — framework name
+- `training.kubeflow.org/job-name` — job name
+- `training.kubeflow.org/replica-type` — replica type (lowercase)
+- `training.kubeflow.org/replica-index` — replica index (0-based)
+
+## Webhooks
+
+Validating webhooks in `pkg/webhooks/<framework>/` check:
+- DNS-compliant job names
+- RunPolicy validity and immutability on update
+- Replica spec requirements (container images, default container name, replica counts)
+
+No mutating webhooks — defaults are applied via the scheme defaulting mechanism.
+
+## Code generation
+
+After modifying types in `pkg/apis/kubeflow.org/v1/`, run `make generate` to produce:
+
+| Output | Generator |
+|--------|-----------|
+| `zz_generated.deepcopy.go` | controller-gen (from `+k8s:deepcopy-gen` markers) |
+| `zz_generated.defaults.go` | k8s code-generator defaulter-gen |
+| `zz_generated.openapi.go` | kube-openapi |
+| `manifests/base/crds/*.yaml` | controller-gen (from kubebuilder markers) |
+| `pkg/client/` | k8s code-generator (clientset, informers, listers, apply configs) |
+| `sdk/python/kubeflow/training/models/` | OpenAPI Generator via `hack/python-sdk/` |
+
+## Python SDK
+
+Two layers in `sdk/python/kubeflow/training/`:
+
+- **Generated** (`models/`) — OpenAPI model classes from Go types. Produced by `hack/python-sdk/gen-sdk.sh`.
+- **Hand-written** — high-level `TrainingClient` class (`api/training_client.py`), job type registry (`constants/constants.py`), and utilities (`utils/utils.py`).
+
+`TrainingClient` provides CRUD operations, status polling, pod/log retrieval, and a high-level `train()` method for LLM fine-tuning.
+
+## Design proposals
+
+The `docs/proposals/` directory contains design documents for significant features:
+
+| Proposal | Topic |
+|----------|-------|
+| `2003-train-api/` | High-level Train/Fine-tune API for LLMs |
+| `2145-jax-integration/` | JAX framework integration (JAXJob CRD) |
+| `2170-kubeflow-training-v2/` | V2 API design using Kubernetes JobSet |
+
+## Deployment
+
+Kustomize manifests in `manifests/`:
+- `base/` — CRDs, RBAC, webhook config, deployment
+- `overlays/standalone/` — standalone deployment variant
+- `rhoai/` — ODH/RHOAI-specific overlay with UBI base image


### PR DESCRIPTION
## Summary

- Add `.claude/skills/` with three SKILL.md files documenting common change patterns:
  - `add-new-job-type`: guide for adding a new distributed training framework
  - `update-crd`: guide for modifying existing CRD type definitions
  - `add-sdk-method`: guide for adding Python SDK methods
- Add `.claude/settings.json` with PostToolUse hooks for `gofmt` and `black` auto-formatting
- Add `ARCHITECTURE.md` documenting controller architecture, CRD relationships, code generation pipeline, SDK layers, and referencing existing `docs/proposals/`

## Test plan

- [x] Validate `.claude/settings.json` is valid JSON (`python3 -m json.tool`)
- [x] Verify all file paths referenced in skill files exist in the repo
- [x] Verify `ARCHITECTURE.md` claims against actual code structure
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added several new guides covering how to update CRDs, add new job types, and extend the Python SDK.
  * Added an architecture overview for the operator, including controller flow, validation, code generation, and SDK structure.

* **Chores**
  * Added tool-use hooks that automatically format Go and Python files after edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->