### PR TITLE
Fix go directive to be compatible with Konflux base image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/training-operator
 
-go 1.25.11
+go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Change go directive from 1.25.11 to 1.25.0 to be compatible with the Konflux ubi9/go-toolset:1.25 base image (Go 1.25.9) which sets GOTOOLCHAIN=local and cannot download newer Go versions.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go version requirement to an earlier 1.25.x release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->