### PR TITLE
fix: handle transient API errors in TLS profile resolution

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -110,6 +110,12 @@ func fetchTLSOpts(cfg *restclient.Config) []func(*tls.Config) {
 				c.MinVersion = tls.VersionTLS12
 				c.CipherSuites = intermediateCiphers
 			})
+		} else if apierrors.IsServiceUnavailable(err) || apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) || errors.Is(err, context.DeadlineExceeded) {
+			setupLog.Info("Transient error fetching TLS profile, using hardened defaults", "error", err)
+			tlsOpts = append(tlsOpts, func(c *tls.Config) {
+				c.MinVersion = tls.VersionTLS12
+				c.CipherSuites = intermediateCiphers
+			})
 		} else {
 			setupLog.Error(err, "Failed to read APIServer TLS profile, operator cannot start without TLS policy")
 			os.Exit(1)


### PR DESCRIPTION
Follow-up to the TLS profile integration. Adds transient error handling (IsServiceUnavailable, IsTimeout, IsTooManyRequests) to the TLS profile fetch, falling back to hardened Intermediate defaults instead of crashing the operator.

Note: this repo does not use SecurityProfileWatcher, so no adherence policy or watcher self-healing changes.

Supersedes #135 (closed due to branch history issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability when the OpenShift API server temporarily returns unavailable, timeout, rate-limit, or deadline-exceeded errors.
  * The application now continues using secure TLS defaults instead of exiting on these transient conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->