### PR TITLE
CVE-2026-32283, CVE-2026-33814: bump go-toolset to 1.26

### DIFF
--- a/build/images/training-operator/Dockerfile.rhoai
+++ b/build/images/training-operator/Dockerfile.rhoai
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/training-operator
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
## Summary
- Update builder image from `go-toolset:1.25` (Go 1.25.9) to `go-toolset:1.26` (Go 1.26.4)
- Fixes CVE-2026-32283 (crypto/tls DoS, CVSS 7.5) and CVE-2026-33814 (HTTP/2 DoS, CVSS 7.5)
- go-toolset:1.25 hasn't been updated since 2026-05-13; go-toolset:1.26 was updated 2026-07-07

## JIRA Tickets
- RHOAIENG-74211, RHOAIENG-74143, RHOAIENG-74090 — CVE-2026-33814 odh-training-operator-rhel9
- RHOAIENG-74659, RHOAIENG-74658 — CVE-2026-32283 (same root cause)

## Test plan
- [x] Verified go-toolset:1.26 ships Go 1.26.4 (includes both CVE fixes)
- [x] Local build with go-toolset:1.26 succeeds (tested on trainer repo, same pattern)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use a newer Go toolset version during image creation and updated the Go toolchain directive.
  * No runtime behavior, features, or user-facing functionality were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->