### PR TITLE
fix: handle transient API errors in TLS profile fetch

### DIFF
--- a/.github/workflows/disconnected-readiness.yml
+++ b/.github/workflows/disconnected-readiness.yml
@@ -1,0 +1,11 @@
+name: Disconnected Readiness
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  check:
+    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@v1
+    with:
+      rules: ""

--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -110,6 +110,12 @@ func fetchTLSOpts(cfg *restclient.Config) []func(*tls.Config) {
 				c.MinVersion = tls.VersionTLS12
 				c.CipherSuites = intermediateCiphers
 			})
+		} else if apierrors.IsServiceUnavailable(err) || apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) || errors.Is(err, context.DeadlineExceeded) {
+			setupLog.Info("Transient error fetching TLS profile, using hardened defaults", "error", err)
+			tlsOpts = append(tlsOpts, func(c *tls.Config) {
+				c.MinVersion = tls.VersionTLS12
+				c.CipherSuites = intermediateCiphers
+			})
 		} else {
 			setupLog.Error(err, "Failed to read APIServer TLS profile, operator cannot start without TLS policy")
 			os.Exit(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated disconnected-readiness checks for pull requests targeting the development branch.

* **Bug Fixes**
  * Improved resilience when retrieving OpenShift API server TLS settings.
  * Transient API errors now fall back to hardened TLS defaults instead of causing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->