### PR TITLE
fix: handle IsServerTimeout in TLS profile resolution

### DIFF
--- a/cmd/training-operator.v1/main.go
+++ b/cmd/training-operator.v1/main.go
@@ -110,7 +110,7 @@ func fetchTLSOpts(cfg *restclient.Config) []func(*tls.Config) {
 				c.MinVersion = tls.VersionTLS12
 				c.CipherSuites = intermediateCiphers
 			})
-		} else if apierrors.IsServiceUnavailable(err) || apierrors.IsTimeout(err) || apierrors.IsTooManyRequests(err) || errors.Is(err, context.DeadlineExceeded) {
+		} else if apierrors.IsServiceUnavailable(err) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) || errors.Is(err, context.DeadlineExceeded) {
 			setupLog.Info("Transient error fetching TLS profile, using hardened defaults", "error", err)
 			tlsOpts = append(tlsOpts, func(c *tls.Config) {
 				c.MinVersion = tls.VersionTLS12


### PR DESCRIPTION
## Description

`apierrors.IsServerTimeout` (StatusReasonServerTimeout) is a distinct Kubernetes error from `apierrors.IsTimeout` (StatusReasonTimeout). The former fires when the API server itself couldn't complete the request in time, the latter when a gateway/proxy times out.

Without handling `IsServerTimeout`, a server-side API timeout during TLS profile fetch falls to the default error case and prevents startup instead of gracefully falling back to Intermediate defaults.

One-line fix, no behavior change for the happy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when retrieving API server TLS security settings during temporary server timeouts.
  * Applies secure default TLS settings instead of treating these transient timeouts as fatal startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->