### PR TITLE
fix: handle dict[K, V] bracket syntax in SDK deserialization

### DIFF
--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -1993,3 +1993,58 @@ def test_get_job_logs(
         assert type(e) is expected_output
 
     print("test execution complete")
+
+
+class TestApiClientDeserializeDictBracketSyntax:
+    """Verify that ApiClient.__deserialize handles the dict[K, V] bracket syntax
+    introduced by kubernetes client v36 alongside the legacy dict(K, V) syntax."""
+
+    def setup_method(self):
+        from kubeflow.training.api_client import ApiClient as KFApiClient
+
+        self.client = KFApiClient()
+
+    def test_dict_parenthesis_syntax(self):
+        data = {"key1": "val1", "key2": "val2"}
+        result = self.client._ApiClient__deserialize(data, "dict(str, str)")
+        assert result == {"key1": "val1", "key2": "val2"}
+
+    def test_dict_bracket_syntax(self):
+        data = {"key1": "val1", "key2": "val2"}
+        result = self.client._ApiClient__deserialize(data, "dict[str, str]")
+        assert result == {"key1": "val1", "key2": "val2"}
+
+    def test_dict_bracket_syntax_with_int_values(self):
+        data = {"cpu": "4", "memory": "8"}
+        result = self.client._ApiClient__deserialize(data, "dict[str, int]")
+        assert result == {"cpu": 4, "memory": 8}
+
+    def test_dict_bracket_syntax_whitespace_variants(self):
+        data = {"a": "1"}
+        assert self.client._ApiClient__deserialize(data, "dict[str,str]") == {"a": "1"}
+        assert self.client._ApiClient__deserialize(data, "dict[ str , str ]") == {
+            "a": "1"
+        }
+
+    def test_dict_bracket_syntax_invalid_raises(self):
+        from kubeflow.training.exceptions import ApiValueError
+
+        with pytest.raises(ApiValueError):
+            self.client._ApiClient__deserialize({}, "dict[str]")
+
+    def test_dict_bracket_syntax_nested_in_model(self):
+        """Simulate deserialization through a model whose openapi_types
+        uses dict[str, str] (kubernetes client >= 36 bracket syntax)."""
+
+        class FakeModel:
+            openapi_types = {"labels": "dict[str, str]"}
+            attribute_map = {"labels": "labels"}
+            discriminator_value_class_map = None
+
+            def __init__(self, labels=None, local_vars_configuration=None):
+                self.labels = labels
+
+        data = {"labels": {"app": "test", "version": "v1"}}
+        result = self.client._ApiClient__deserialize(data, FakeModel)
+        assert isinstance(result, FakeModel)
+        assert result.labels == {"app": "test", "version": "v1"}

--- a/sdk/python/kubeflow/training/api_client.py
+++ b/sdk/python/kubeflow/training/api_client.py
@@ -296,8 +296,12 @@ class ApiClient(object):
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
-            if klass.startswith('dict('):
-                sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
+            if klass.startswith('dict(') or klass.startswith('dict['):
+                m = re.match(r'dict[\(\[]\s*([^,]*?)\s*,\s*(.*?)\s*[\)\]]$', klass)
+                if m is None:
+                    raise ApiValueError(
+                        "Failed to parse dict type: {}".format(klass))
+                sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in six.iteritems(data)}
 


### PR DESCRIPTION
kubernetes client v36 changed openapi_types annotations from dict(str, str) to dict[str, str]. The SDK's ApiClient.__deserialize only handled the parenthesis form, causing AttributeError when deserializing any model with map fields (labels, annotations, resource limits, etc.).

Resolves: RHOAIENG-75322

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python SDK deserialization of dictionary type annotations, now supporting both `dict(str, str)` and `dict[str, str]` bracket syntax.
  * Correctly converts and deserializes values (including `int`-typed values), handles whitespace variations, and raises a clear error for invalid dictionary type strings.
  * Ensures nested model dictionary annotations deserialize as expected.
* **Tests**
  * Added coverage for bracket syntax behavior, error cases, and nested model deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->