### PR TITLE
chore: bump Python SDK version to 1.9.3+rhaiv.3 for midstream release

### DIFF
--- a/sdk/python/kubeflow/training/__init__.py
+++ b/sdk/python/kubeflow/training/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-__version__ = "1.9.3"
+__version__ = "1.9.3+rhaiv.3"
 
 # import apis into sdk package
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -33,7 +33,7 @@ REQUIRES = [
 
 setuptools.setup(
     name="kubeflow-training",
-    version="1.9.3",
+    version="1.9.3+rhaiv.3",
     author="Kubeflow Authors",
     author_email="hejinchi@cn.ibm.com",
     license="Apache License Version 2.0",


### PR DESCRIPTION
## Summary
- Bumps Python SDK version to `1.9.3+rhaiv.3` following Red Hat tagging pattern
- Transitions from the legacy `-N` build suffix to `+rhaiv.N` for correct PEP 440 version ordering
- Continues build number from previous midstream build `1.9.3-2`

## Files changed
- `sdk/python/setup.py` — version `1.9.3` → `1.9.3+rhaiv.3`
- `sdk/python/kubeflow/training/__init__.py` — `__version__` `1.9.3` → `1.9.3+rhaiv.3`

## Post-merge flow
1. Merge this PR into `dev`
2. Sync `dev` → `stable` (lake-gate)
3. Sync `stable` → `rhoai` (ocean-gate)
4. Tag the rhoai merge commit: `git tag v1.9.3+rhaiv.3 <sha> && git push odh-training v1.9.3+rhaiv.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)